### PR TITLE
feat(arithmetic): add total-domain u32 right shift

### DIFF
--- a/examples/u32_total_domain_rshift_benchmark.rs
+++ b/examples/u32_total_domain_rshift_benchmark.rs
@@ -1,0 +1,81 @@
+//! Compare the one-item compressed u32 right shift with the four-byte wire.
+
+use bitcoin::consensus::encode::serialize;
+use bitcoin::{script::Instruction, Witness};
+use bitcoin_lab::{
+    arithmetic::u32::{rshift::*, stack::*},
+    support::{execution::execute_script_with_inputs_strict, script::ScriptCompilation},
+};
+use bitcoin_script::script;
+
+fn scriptnum(value: i64) -> Vec<u8> {
+    let mut bytes = [0u8; 8];
+    let len = bitcoin::script::write_scriptint(&mut bytes, value);
+    bytes[..len].to_vec()
+}
+
+fn compressed_witness(value: u32) -> Vec<Vec<u8>> {
+    vec![scriptnum(i64::from(value as i32))]
+}
+
+fn byte_witness(value: u32) -> Vec<Vec<u8>> {
+    [
+        value >> 24,
+        (value >> 16) & 0xff,
+        (value >> 8) & 0xff,
+        value & 0xff,
+    ]
+    .into_iter()
+    .map(|byte| scriptnum(i64::from(byte)))
+    .collect()
+}
+
+fn witness_bytes(items: &[Vec<u8>]) -> usize {
+    serialize(&Witness::from_slice(items)).len()
+}
+
+fn static_non_push_opcodes(script: bitcoin_script::Script) -> usize {
+    script
+        .compile_with_policy()
+        .instructions()
+        .map(|instruction| instruction.expect("generated script must parse"))
+        .filter(
+            |instruction| matches!(instruction, Instruction::Op(opcode) if opcode.to_u8() > 0x60),
+        )
+        .count()
+}
+
+fn main() {
+    let value = 0xa5c3_19e7;
+    println!("shift compressed_bytes byte_bytes compressed_witness byte_witness compressed_stack byte_stack compressed_static_ops byte_static_ops");
+    for shift in [1, 3, 7, 8, 15, 16, 23, 24, 31] {
+        let compressed = script! {
+            { u32_compressed_rshift(shift) }
+            OP_DROP
+            OP_TRUE
+        };
+        let bytes = script! {
+            { u32_bytes_rshift(shift) }
+            { u32_drop() }
+            OP_TRUE
+        };
+        let compressed_input = compressed_witness(value);
+        let byte_input = byte_witness(value);
+        let compressed_result =
+            execute_script_with_inputs_strict(compressed.clone(), compressed_input.clone());
+        let byte_result = execute_script_with_inputs_strict(bytes.clone(), byte_input.clone());
+        assert!(compressed_result.success, "compressed shift {shift} failed");
+        assert!(byte_result.success, "byte shift {shift} failed");
+        println!(
+            "{shift} {} {} {} {} {} {} {} {}",
+            compressed.clone().compile_with_policy().len(),
+            bytes.clone().compile_with_policy().len(),
+            witness_bytes(&compressed_input),
+            witness_bytes(&byte_input),
+            compressed_result.stats.max_nb_stack_items,
+            byte_result.stats.max_nb_stack_items,
+            static_non_push_opcodes(compressed),
+            static_non_push_opcodes(bytes),
+        );
+    }
+}

--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1,8 +1,97 @@
 {
   "schema_version": 1,
-  "as_of": "2026-09-01",
+  "as_of": "2026-09-10",
   "cost_model": "knowledge/cost-model.md",
   "records": [
+    {
+      "id": "arithmetic/u32-total-domain-rshift",
+      "name": "Total-domain compressed u32 logical right shift",
+      "class": "arithmetic/word",
+      "summary": "Checked logical right shift for the one-item compressed u32 wire, including the canonical five-byte 0x80000000 sentinel.",
+      "status": "experimental",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-10",
+      "knowledge_page": "knowledge/primitives/u32-total-domain-rshift.md",
+      "implementation": "src/arithmetic/u32/rshift.rs",
+      "documentation": "src/arithmetic/u32/README.md",
+      "tests": [
+        "arithmetic::u32::rshift::tests",
+        "tests/primitive_metrics::total_domain_rshift_metrics_are_current",
+        "examples/u32_total_domain_rshift_benchmark.rs"
+      ],
+      "references": [
+        "bitcoin-script-locked",
+        "bitcoin-scriptexec-locked",
+        "coins-bitcoin-scripts-8f442e4b"
+      ],
+      "techniques": [
+        "compact-wire",
+        "digit-arithmetic",
+        "lookup-table",
+        "representation"
+      ],
+      "security": "The compressed word is hostile witness data. Checked mode rejects non-minimal encodings, negative zero, wrong-width items, and invalid five-byte values before numeric decoding. No cryptographic claim.",
+      "stack_contract": "compressed ScriptNum -> compressed ScriptNum; the four-byte baseline consumes and returns four byte-valued stack items",
+      "configurations": [
+        {
+          "id": "compressed-shift7",
+          "label": "Compressed one-item wire, logical shift 7",
+          "parameters": {
+            "shift": 7,
+            "semantic_value": "0xa5c319e7",
+            "hint_items_per_invocation": 0,
+            "complete_witness_items": 1
+          },
+          "includes": "fragment-with-memory: canonical input certification, u32 expansion, shared 256-entry byte-logic table setup and cleanup, rotate/mask, recompression, output drop, and terminal truth; excludes input pushes and transaction framing",
+          "script_bytes": 1143,
+          "witness_bytes": 6,
+          "witness_bytes_max": 6,
+          "max_stack_items": 272,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 236,
+          "per_use_script_bytes": 1143,
+          "metric_keys": [
+            "u32_rshift_compressed_7",
+            "u32_rshift_compressed_7_witness",
+            "u32_rshift_compressed_7_stack"
+          ]
+        },
+        {
+          "id": "four-byte-baseline-shift7",
+          "label": "Four-byte u32 rotate/mask baseline, logical shift 7",
+          "parameters": {
+            "shift": 7,
+            "semantic_value": "0xa5c319e7",
+            "hint_items_per_invocation": 0,
+            "complete_witness_items": 4
+          },
+          "includes": "fragment-with-memory: shared 256-entry byte-logic table setup and cleanup, rotate/mask, output drop, and terminal truth; excludes input pushes and transaction framing",
+          "script_bytes": 637,
+          "witness_bytes": 12,
+          "witness_bytes_max": 12,
+          "max_stack_items": 272,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 236,
+          "per_use_script_bytes": 637,
+          "metric_keys": [
+            "u32_rshift_bytes_7",
+            "u32_rshift_bytes_7_witness",
+            "u32_rshift_bytes_7_stack"
+          ]
+        }
+      ],
+      "limitations": [
+        "The compressed form loses locking-script bytes and has the same local peak because the 256-item table dominates",
+        "The local executor did not expose a useful dynamic opcode count or validation-weight result",
+        "No complete leaf, transaction, Bitcoin Core differential validation, or relay-policy validation"
+      ],
+      "open_problems": [
+        "OP-014"
+      ]
+    },
     {
       "id": "arithmetic/scriptnum-constant-mul",
       "name": "ScriptNum constant multiplication",

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Total-domain compressed u32 right shift, shift 7 | one-item compressed wire | 1,143 | 6-byte witness and 1 entry item; four-byte baseline is 637 bytes and 12-byte witness |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |
@@ -33,6 +34,14 @@ but longer expressions remain modular unless their bound is proved below its
 513-bit composite modulus. Range checks and conversion remain outside a row
 unless its boundary says otherwise; terminal predicates remain excluded from
 both modular-product rows.
+
+The compressed u32 right-shift wire closes the local `0x80000000` negative-zero
+edge and reduces the witness from four byte items to one compressed ScriptNum.
+At shift 7 it costs 1,143 locking bytes versus 637 for the four-byte
+rotate/mask baseline, while reducing serialized witness bytes from 12 to 6 and
+entry items from four to one. It is a witness-width tradeoff, not a byte-size
+winner; OP-014 still requires Bitcoin Core differential and complete-transaction
+validation.
 
 The 9,893-byte Ed25519 row is the current locking-script-size winner for this
 field. It keeps host values in the ordinary field domain but uses a unique

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -6,7 +6,7 @@ reproducible constructions. The local Rust library is one source of evidence;
 it is not the boundary of the atlas.
 
 The catalog is explicitly time-scoped. Its current review date is
-**2026-09-04**. A record's `as_of` field says when its claims were last checked.
+**2026-09-10**. A record's `as_of` field says when its claims were last checked.
 Missing records are unknown coverage, not proof of nonexistence.
 
 ## How to answer a research question

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,18 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+
+## NR-043: Compressed total-domain u32 shifts lose locking bytes
+
+The second seed-directed primitive implements logical right shift over the
+one-item compressed u32 wire, including the canonical five-byte `0x80000000`
+sentinel. It is locally correct for every shift `1..=31` on the documented
+boundary classes and rejects non-minimal, negative-zero, wrong-width, and
+invalid five-byte inputs. At shift 7 the compressed boundary is 1,143 locking
+bytes, 6 witness bytes, and one entry item; the direct four-byte rotate/mask
+baseline is 637 locking bytes, 12 witness bytes, and four entry items. The
+strict peak is 272 items for both, because the shared 256-item byte table
+dominates. The compressed form is therefore dominated for locking bytes and
+combined local stack peak, but remains a possible witness-width optimization.
+These measurements are `locally-reproduced` and do not establish a universal
+lower bound or Bitcoin Core deployability.

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -293,6 +293,14 @@ setup, script bytes, executed opcodes, and strict stack peaks are compared on
 the same boundary; malformed encodings are rejected; and a complete tapscript
 leaf is differentially validated against a pinned Bitcoin Core revision.
 
+The local compressed-wire experiment supplies a partial frontier result:
+`u32_compressed_rshift` handles all shifts `1..=31`, recognizes the canonical
+five-byte encoding of `0x80000000`, and rejects malformed raw words. Its
+shift-7 boundary is 1,143 locking bytes with a 6-byte one-item witness versus
+637 bytes and a 12-byte four-item witness for the direct u32 baseline. The
+problem remains open until the complete boundary is differentially validated
+against pinned Bitcoin Core and measured in a complete leaf/transaction.
+
 ## OP-015 — Native secp256k1 field circuit frontier
 
 Turn the native 20,503-byte ordinary multiplication, 20,450-byte factor-16

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -10,6 +10,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [Hinted ScriptNum division](scriptnum-hinted-div.md)
 - [u4 digit arithmetic](u4.md)
 - [u32 word arithmetic](u32.md)
+- [Total-domain compressed u32 logical right shift](u32-total-domain-rshift.md)
 - [u31 prime-field arithmetic](u31.md)
 - [Native secp256k1 base-field arithmetic](secp256k1-field.md)
 - [Ed25519 base-field multiplication](ed25519-field.md)

--- a/knowledge/primitives/u32-total-domain-rshift.md
+++ b/knowledge/primitives/u32-total-domain-rshift.md
@@ -1,0 +1,83 @@
+# Total-domain compressed u32 logical right shift
+
+## Question and hypothesis
+
+Can the repository's one-item compressed u32 wire support a total-domain
+logical right shift without losing the `0x80000000` semantic word to ScriptNum
+negative-zero behavior? The hypothesis is that a canonical raw-wire check plus
+the existing byte rotation/AND machinery can close that correctness gap while
+reducing witness item count from four bytes to one.
+
+## Construction and objective
+
+`u32_compressed_rshift(shift)` accepts the exact compressed representation
+produced by `u32_compress`, for `1..=31`, and returns the compressed encoding of
+`value >> shift`. It accepts the unique five-byte encoding of `-2^31` as the
+wire for `0x80000000`; all other five-byte values, non-minimal aliases,
+negative zero, and wrong-width items are rejected. The operation expands to
+four bytes, rotates right, masks the high bits with the existing shared byte
+logic table, and recompresses.
+
+The comparison objective is witness width under equal strict local tapscript
+execution. The closest baseline is the same rotate/mask operation over four
+byte-valued witness items. Locking-script bytes, complete witness bytes,
+coexisting data items, combined stack peak, and static non-push opcodes are
+reported at a common fragment boundary. There are zero auxiliary hints.
+
+## Measured result
+
+The representative boundary uses shift 7 and semantic value `0xa5c319e7`.
+It includes canonical input validation, table setup and cleanup, rotation,
+masking, output compression or byte restoration, output dropping, and a
+terminal `OP_TRUE`; witness input pushes and transaction framing are excluded.
+
+| Configuration | Locking script | Witness | Complete items | Peak stack | Static non-push opcodes |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Compressed one-item wire | <!-- metric:u32_rshift_compressed_7 -->1143<!-- /metric:u32_rshift_compressed_7 --> bytes | <!-- metric:u32_rshift_compressed_7_witness -->6<!-- /metric:u32_rshift_compressed_7_witness --> bytes | 1 | <!-- metric:u32_rshift_compressed_7_stack -->272<!-- /metric:u32_rshift_compressed_7_stack --> | <!-- metric:u32_rshift_compressed_7_static_opcodes -->863<!-- /metric:u32_rshift_compressed_7_static_opcodes --> |
+| Four-byte u32 baseline | <!-- metric:u32_rshift_bytes_7 -->637<!-- /metric:u32_rshift_bytes_7 --> bytes | <!-- metric:u32_rshift_bytes_7_witness -->12<!-- /metric:u32_rshift_bytes_7_witness --> bytes | 4 | <!-- metric:u32_rshift_bytes_7_stack -->272<!-- /metric:u32_rshift_bytes_7_stack --> | <!-- metric:u32_rshift_bytes_7_static_opcodes -->473<!-- /metric:u32_rshift_bytes_7_static_opcodes --> |
+
+The compressed wire saves 6 serialized witness bytes and three entry items,
+but adds 506 locking-script bytes and 390 static non-push opcodes. A
+deterministic sweep confirms the same direction at shifts 1, 3, 7, 8, 15,
+16, 23, 24, and 31. This is therefore a useful total-domain and witness-width
+primitive, not a locking-script-size improvement.
+
+The local executor reports zero dynamic opcode counts for this standalone
+fragment, so dynamic execution counts and validation weight are recorded as
+unknown rather than zero. Static counts are a separate reproducible metric.
+
+## Correctness and threat model
+
+The input is hostile witness data. The checked wrapper enforces canonical raw
+ScriptNum encoding, recognizes only the canonical five-byte `-2^31` sentinel,
+and rejects negative zero, non-minimal aliases, and wrong-width values before
+using `u32_uncompress`. Deterministic tests cover every shift `1..=31` for
+`0`, `0x7fffffff`, `0x80000000`, and `0xffffffff`, cross-byte mixed values,
+non-minimal values, negative zero, invalid five-byte values, and six-byte
+inputs.
+
+This is local correctness evidence only. Tests use the pinned
+`bitcoin-scriptexec` tapscript helper with the strict local stack limit. No
+Bitcoin Core differential validation, relay-policy validation, complete leaf,
+or cryptographic security claim is made; the execution class is
+`unclassified` and the evidence level is `locally-reproduced`.
+
+## Provenance
+
+The ScriptNum/u32 representation and the negative-zero edge were checked
+against the immutable `coins/bitcoin-scripts` source snapshot
+`8f442e4bf8a744dd9bf69b2937bdebcaed5cae77`, registered as
+`coins-bitcoin-scripts-8f442e4b`. Local execution uses the immutable
+`bitcoin-script` and `bitcoin-scriptexec` revisions registered in
+`knowledge/references/sources.json`.
+
+## Reproduction
+
+```sh
+cargo test --locked arithmetic::u32::rshift --lib
+cargo test --locked --test primitive_metrics total_domain_rshift_metrics_are_current
+cargo run --locked --release --example u32_total_domain_rshift_benchmark
+```
+
+The open-problem target remains OP-014: close the Core differential and
+complete-transaction boundary before calling this deployable.

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -10,8 +10,12 @@ stack manipulation.
 - **Tradeoff:** operation fragments are moderate, while a reusable Boolean table
   occupies 256 stack items.
 - **Representative results:** add is 78 bytes; subtract is 77; less-than is 39.
+- **Total-domain shift:** the compressed one-item right-shift wrapper handles
+  `0x80000000` and malformed raw words, but is larger than the four-byte
+  rotate/mask baseline; it saves witness width rather than locking bytes.
 - **Consumers:** SHA-1, SHA-256, RIPEMD-160, and SHAKE256.
 
 See the [implementation README](../../src/arithmetic/u32/README.md),
+[total-domain right-shift page](u32-total-domain-rshift.md),
 [technique page](../techniques/representations.md), and catalog record
 `arithmetic/u32`.

--- a/research/u32-total-domain-rshift/README.md
+++ b/research/u32-total-domain-rshift/README.md
@@ -1,0 +1,47 @@
+# Total-domain compressed u32 logical right shift
+
+## Question
+
+Can the one-item compressed u32 wire implement logical right shifts for every
+semantic 32-bit word, including `0x80000000`, without accepting ambiguous raw
+ScriptNum encodings?
+
+## Hypothesis and objective
+
+Canonical raw-wire certification plus the existing u32 rotate/mask helpers
+should close the negative-zero gap and reduce witness item count from four to
+one. The comparison minimizes witness serialization and entry stack items
+under a common strict tapscript boundary; locking-script bytes and static
+opcode count are secondary costs.
+
+## Threat model and execution class
+
+The compressed word is hostile witness data. Non-minimal encodings, negative
+zero, invalid five-byte values, and wrong-width items must be rejected before
+numeric decoding. The local result is `locally-reproduced` and
+`unclassified`: it uses the pinned local tapscript interpreter and strict
+1,000-item stack checks, without Bitcoin Core or relay-policy differential
+validation.
+
+## Deterministic vectors and boundary
+
+Every shift `1..=31` is tested for `0`, `0x7fffffff`, `0x80000000`, and
+`0xffffffff`; mixed values `0x01020304` and `0xa5c319e7` use shifts 3, 11,
+19, and 27. Malformed vectors include non-minimal `1`, negative zero, an
+invalid five-byte word, and a six-byte word. Metrics use shift 7 and
+`0xa5c319e7`, with table setup/cleanup, output cleanup, and `OP_TRUE` included;
+input pushes and transaction framing are excluded.
+
+## Reproduction
+
+```sh
+cargo test --locked arithmetic::u32::rshift --lib
+cargo test --locked --test primitive_metrics total_domain_rshift_metrics_are_current
+cargo run --locked --release --example u32_total_domain_rshift_benchmark
+python3 tools/kb.py validate
+```
+
+The four-byte rotate/mask construction is the direct baseline. The compressed
+wire wins witness bytes and entry item count but loses locking-script bytes;
+that tradeoff is retained as a reproducible frontier result rather than being
+presented as a universal optimization.

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -45,6 +45,35 @@ words inside the locking script or supply four witness items per word. No
 operation-specific hint is needed. The logic table can be shared by any number
 of XOR, AND, and OR operations in one script.
 
+## Total-domain compressed logical right shift
+
+`u32_compressed_rshift(shift)` accepts one exact compressed u32 ScriptNum,
+including the canonical five-byte encoding of `0x80000000`, and returns the
+compressed ScriptNum for the logical result. It rejects non-minimal encodings,
+negative zero, wrong-width items, and five-byte values other than `-2^31`.
+Internally it expands to four bytes, uses the existing rotation and shared
+byte-AND table, then recompresses. The four-byte operation is retained as the
+like-for-like witness-width baseline.
+
+The representative rows use shift 7, the deterministic value `0xa5c319e7`,
+strict local tapscript execution, and include table setup/cleanup, canonical
+input validation, output compression, and a terminal `OP_TRUE`; witness input
+pushes are excluded from locking-script bytes. Both rows require zero
+auxiliary hint items.
+
+| Configuration | Locking script | Witness | Complete items | Peak stack | Static non-push opcodes |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Compressed one-item wire | <!-- metric:u32_rshift_compressed_7 -->1143<!-- /metric:u32_rshift_compressed_7 --> bytes | <!-- metric:u32_rshift_compressed_7_witness -->6<!-- /metric:u32_rshift_compressed_7_witness --> bytes | 1 | <!-- metric:u32_rshift_compressed_7_stack -->272<!-- /metric:u32_rshift_compressed_7_stack --> | <!-- metric:u32_rshift_compressed_7_static_opcodes -->863<!-- /metric:u32_rshift_compressed_7_static_opcodes --> |
+| Four-byte u32 baseline | <!-- metric:u32_rshift_bytes_7 -->637<!-- /metric:u32_rshift_bytes_7 --> bytes | <!-- metric:u32_rshift_bytes_7_witness -->12<!-- /metric:u32_rshift_bytes_7_witness --> bytes | 4 | <!-- metric:u32_rshift_bytes_7_stack -->272<!-- /metric:u32_rshift_bytes_7_stack --> | <!-- metric:u32_rshift_bytes_7_static_opcodes -->473<!-- /metric:u32_rshift_bytes_7_static_opcodes --> |
+
+The compressed wire trades locking-script bytes and execution work for three
+fewer entry witness items. This is a representation primitive, not a complete
+leaf or a consensus/deployability claim.
+
+The local executor did not expose a useful dynamic opcode count for this
+standalone fragment, so static non-push counts are reported instead; no
+validation-weight result is claimed.
+
 ## Security
 
 There is no independent cryptographic security parameter. Arithmetic is exact

--- a/src/arithmetic/u32/mod.rs
+++ b/src/arithmetic/u32/mod.rs
@@ -3,6 +3,7 @@ pub mod and;
 pub mod cmp;
 pub mod or;
 pub mod rotate;
+pub mod rshift;
 pub mod stack;
 pub mod sub;
 pub mod xor;

--- a/src/arithmetic/u32/rshift.rs
+++ b/src/arithmetic/u32/rshift.rs
@@ -1,0 +1,114 @@
+//! Total-domain logical right shifts for the compressed one-item u32 wire.
+
+use crate::{
+    arithmetic::u32::{and::u32_and, rotate::u32_rrot, stack::*},
+    support::script::*,
+};
+
+fn certify_compressed_word() -> Script {
+    script! {
+        OP_SIZE 5 OP_NUMEQUAL
+        OP_IF
+            OP_DUP { -2_147_483_648i64 } OP_EQUALVERIFY
+        OP_ELSE
+            OP_DUP OP_DUP 0 OP_ADD OP_EQUALVERIFY
+        OP_ENDIF
+    }
+}
+
+/// Logically shift four byte-valued u32 limbs right by `shift` bits.
+///
+/// Before and after: `byte[3] | byte[2] | byte[1] | byte[0]`, with the
+/// least-significant byte on top. The shared byte-logic table is installed
+/// internally and the result preserves no input copy.
+pub fn u32_bytes_rshift(shift: usize) -> Script {
+    assert!((1..=31).contains(&shift));
+    let mask = u32::MAX >> shift;
+    script! {
+        { u32_rrot(shift) }
+        { u32_toaltstack() }
+        { crate::arithmetic::u32::xor::u8_push_xor_table() }
+        { u32_fromaltstack() }
+        { u32_push(mask) }
+        { u32_and(0, 1, 3) }
+        { u32_toaltstack() }
+        { u32_drop() }
+        { crate::arithmetic::u32::xor::u8_drop_xor_table() }
+        { u32_fromaltstack() }
+    }
+}
+
+/// Logically shift a compressed u32 word right by `shift` bits.
+///
+/// The input and output are the one-item compressed representation produced by
+/// [`u32_compress`]. The `0x8000_0000` word is handled through the canonical
+/// five-byte negative ScriptNum representation rather than numeric sign
+/// semantics. The shared byte-logic table is installed internally.
+pub fn u32_compressed_rshift(shift: usize) -> Script {
+    assert!((1..=31).contains(&shift));
+    script! {
+        { certify_compressed_word() }
+        { u32_uncompress() }
+        { u32_bytes_rshift(shift) }
+        { u32_compress() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::support::execution::{execute_raw_script_with_inputs_strict, execute_script};
+
+    #[test]
+    fn compressed_shift_covers_semantic_boundaries() {
+        let values = [0, 0x7fff_ffff, 0x8000_0000, 0xffff_ffff];
+        for value in values {
+            for shift in 1..=31 {
+                let result = execute_script(script! {
+                    { u32_push(value) }
+                    { u32_compress() }
+                    { u32_compressed_rshift(shift) }
+                    { u32_push(value >> shift) }
+                    { u32_compress() }
+                    OP_EQUAL
+                });
+                assert!(result.success, "value={value:#x}, shift={shift}: {result}");
+            }
+        }
+        for value in [0x0102_0304, 0xa5c3_19e7] {
+            for shift in [3, 11, 19, 27] {
+                let result = execute_script(script! {
+                    { u32_push(value) }
+                    { u32_compress() }
+                    { u32_compressed_rshift(shift) }
+                    { u32_push(value >> shift) }
+                    { u32_compress() }
+                    OP_EQUAL
+                });
+                assert!(result.success, "value={value:#x}, shift={shift}: {result}");
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_noncanonical_and_wrong_width_inputs() {
+        let script = script! {
+            { u32_compressed_rshift(1) }
+            OP_TRUE
+        }
+        .compile_with_policy()
+        .to_bytes();
+        for raw in [
+            vec![1, 0],
+            vec![0, 0, 0, 0x80],
+            vec![1, 0, 0, 0, 0],
+            vec![1, 0, 0, 0, 0, 0],
+        ] {
+            let result = execute_raw_script_with_inputs_strict(script.clone(), vec![raw]);
+            assert!(
+                !result.success,
+                "accepted malformed compressed word: {result}"
+            );
+        }
+    }
+}

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -93,6 +93,81 @@ fn max_stack_items_strict(script: bitcoin_script::Script, witness: Vec<Vec<u8>>)
     result.stats.max_nb_stack_items
 }
 
+fn compressed_u32_witness(value: u32) -> Vec<Vec<u8>> {
+    vec![scriptnum(i64::from(value as i32))]
+}
+
+fn byte_u32_witness(value: u32) -> Vec<Vec<u8>> {
+    [
+        (value >> 24) & 0xff,
+        (value >> 16) & 0xff,
+        (value >> 8) & 0xff,
+        value & 0xff,
+    ]
+    .into_iter()
+    .map(|byte| scriptnum(i64::from(byte)))
+    .collect()
+}
+
+fn total_domain_rshift_metrics() -> Vec<Metric> {
+    const SHIFT: usize = 7;
+    const VALUE: u32 = 0xa5c3_19e7;
+    let compressed = script! {
+        { u32::rshift::u32_compressed_rshift(SHIFT) }
+        OP_DROP
+        OP_TRUE
+    };
+    let bytes = script! {
+        { u32::rshift::u32_bytes_rshift(SHIFT) }
+        { u32::stack::u32_drop() }
+        OP_TRUE
+    };
+    let compressed_witness = compressed_u32_witness(VALUE);
+    let byte_witness = byte_u32_witness(VALUE);
+    vec![
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_rshift_compressed_7",
+            value: script_len(compressed.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_rshift_compressed_7_witness",
+            value: witness_size(&compressed_witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_rshift_compressed_7_stack",
+            value: max_stack_items_strict(compressed.clone(), compressed_witness.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_rshift_compressed_7_static_opcodes",
+            value: static_non_push_opcodes(compressed),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_rshift_bytes_7",
+            value: script_len(bytes.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_rshift_bytes_7_witness",
+            value: witness_size(&byte_witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_rshift_bytes_7_stack",
+            value: max_stack_items_strict(bytes.clone(), byte_witness.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_rshift_bytes_7_static_opcodes",
+            value: static_non_push_opcodes(bytes),
+        },
+    ]
+}
+
 fn prince_metrics() -> Vec<Metric> {
     let fragment = prince::prince_encrypt(0);
     let compiled = fragment.clone().compile_with_policy();
@@ -3995,6 +4070,7 @@ fn metrics() -> Vec<Metric> {
     .chain(winternitz_overview_metrics())
     .chain(winternitz20_metrics())
     .chain(winternitz20_composition_metrics())
+    .chain(total_domain_rshift_metrics())
     .collect()
 }
 
@@ -4035,6 +4111,11 @@ fn winternitz20_metrics_are_current() {
 #[test]
 fn prince_metrics_are_current() {
     check_readme_metrics(prince_metrics());
+}
+
+#[test]
+fn total_domain_rshift_metrics_are_current() {
+    check_readme_metrics(total_domain_rshift_metrics());
 }
 
 /// This isolated fixture exercises only the two small packed decoders. It


### PR DESCRIPTION
## Summary

- add a compressed ScriptNum u32 logical right shift covering the full `0..=0xffffffff` domain
- certify canonical compressed inputs, including the `0x80000000` negative-zero sentinel
- add malformed-input tests, boundary vectors, benchmark output, metrics, and knowledge-base records

## Measured shift-7 boundary

| Construction | Locking script | Witness | Stack peak | Static non-push opcodes |
| --- | ---: | ---: | ---: | ---: |
| Compressed ScriptNum | 1143 bytes | 6 bytes | 272 items | 863 |
| Four-byte baseline | 637 bytes | 12 bytes | 272 items | 473 |

The compressed form saves witness width but is not a locking-byte or combined-stack improvement. Dynamic opcode and validation-weight measurements are not available from the local executor.

## Focused verification

- `cargo test --locked arithmetic::u32::rshift --lib`
- `cargo test --locked --test primitive_metrics total_domain_rshift_metrics_are_current`
- `cargo test --locked --test knowledge_base`
- `cargo fmt --all -- --check`
- `python3 tools/kb.py validate`
- `cargo run --locked --release --example u32_total_domain_rshift_benchmark`

The full repository test suite was not run, per request; validation was limited to the affected primitive, metrics, knowledge-base validation, formatting, and benchmark.
