### PR TITLE
feat(ciphers): expose checked PRINCEv2 M-hat layer

### DIFF
--- a/examples/prince_m_layer_benchmark.rs
+++ b/examples/prince_m_layer_benchmark.rs
@@ -1,0 +1,49 @@
+use bitcoin::consensus::encode::serialize;
+use bitcoin::{script::Instruction, Witness};
+use bitcoin_lab::{
+    ciphers::prince::prince_m_layer,
+    support::{execution::execute_script_with_inputs_strict, script::ScriptCompilation},
+};
+use bitcoin_script::script;
+
+fn main() {
+    let fragment = prince_m_layer();
+    let compiled = fragment.clone().compile_with_policy();
+    let witness: Vec<Vec<u8>> = [
+        0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf,
+    ]
+    .into_iter()
+    .rev()
+    .map(|nibble| if nibble == 0 { vec![] } else { vec![nibble] })
+    .collect();
+    let execution_leaf = script! {
+        { fragment }
+        for _ in 0..8 { OP_2DROP }
+        OP_TRUE
+    };
+    let result = execute_script_with_inputs_strict(execution_leaf, witness.clone());
+    assert!(result.success, "benchmark vector failed: {result}");
+
+    let static_non_push = compiled
+        .instructions()
+        .map(|instruction| instruction.expect("generated fragment must parse"))
+        .filter(
+            |instruction| matches!(instruction, Instruction::Op(opcode) if opcode.to_u8() > 0x60),
+        )
+        .count();
+    println!("script_bytes={}", compiled.len());
+    println!(
+        "witness_bytes={}",
+        serialize(&Witness::from_slice(&witness)).len()
+    );
+    println!("witness_data_items={}", witness.len());
+    println!("hint_items=0");
+    println!("stack_peak={}", result.stats.max_nb_stack_items);
+    println!("executed_opcodes={}", result.stats.opcode_count);
+    println!("static_non_push_opcodes={static_non_push}");
+    println!(
+        "validation_weight_delta={}",
+        result.stats.start_validation_weight - result.stats.validation_weight
+    );
+    println!("context=tapscript stack_limit=1000");
+}

--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1,8 +1,77 @@
 {
   "schema_version": 1,
-  "as_of": "2026-09-01",
+  "as_of": "2026-09-10",
   "cost_model": "knowledge/cost-model.md",
   "records": [
+    {
+      "id": "cipher/princev2-mhat",
+      "name": "PRINCEv2 standalone M-hat layer",
+      "class": "cipher/linear-layer",
+      "summary": "Reusable four-block PRINCEv2 M-hat transformation over a checked 16-nibble state.",
+      "status": "experimental",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-10",
+      "knowledge_page": "knowledge/primitives/princev2-mhat.md",
+      "implementation": "src/ciphers/prince/mod.rs",
+      "documentation": "src/ciphers/prince/README.md",
+      "tests": [
+        "ciphers::prince::tests::test_optimized_m_layer_boundaries_and_random_state",
+        "ciphers::prince::tests::test_optimized_m_layer_rejects_invalid_nibbles_and_short_input",
+        "primitive_metrics::prince_metrics_are_current",
+        "examples/prince_m_layer_benchmark.rs"
+      ],
+      "references": [
+        "princev2-reference",
+        "bitcoin-script-locked",
+        "bitcoin-scriptexec-locked"
+      ],
+      "techniques": [
+        "digit-arithmetic",
+        "lookup-table",
+        "stack-scheduling",
+        "range-check"
+      ],
+      "security": "No independent cryptographic claim. Numeric nibble range checks protect lookup-derived stack depths; minimally encoded witness bytes and complete protocol binding remain caller obligations.",
+      "stack_contract": "... nibble[15] ... nibble[0] -> ... output[15] ... output[0]; the top 16 items are checked numeric nibbles and unrelated items below them are preserved.",
+      "configurations": [
+        {
+          "id": "standalone-zero-key-layout",
+          "label": "Standalone four-block M-hat layer",
+          "parameters": {
+            "state_nibbles": 16,
+            "table_layout": "zero-key packed scheduler",
+            "hint_items_per_invocation": 0,
+            "complete_input_items": 16
+          },
+          "includes": "fragment-with-memory: numeric nibble checks, packed lookup setup, four M-hat blocks, output ordering, and table cleanup; excludes input pushes, output consumption, tapleaf/control-block bytes, transaction framing, and unrelated live state",
+          "script_bytes": 1565,
+          "witness_bytes": 32,
+          "witness_bytes_max": 33,
+          "max_stack_items": 633,
+          "executed_opcodes": null,
+          "validation_weight": 0,
+          "setup_script_bytes": null,
+          "per_use_script_bytes": 1565,
+          "metric_keys": [
+            "prince_m_layer",
+            "prince_m_layer_witness",
+            "prince_m_layer_stack",
+            "prince_m_layer_hints"
+          ]
+        }
+      ],
+      "limitations": [
+        "Reusable linear layer, not a complete PRINCEv2 encryption leaf",
+        "Dynamic opcode count is unavailable from the local executor",
+        "Canonical witness-byte encoding, complete transaction, Bitcoin Core, and relay-policy validation remain open"
+      ],
+      "open_problems": [
+        "OP-002",
+        "OP-003",
+        "OP-019"
+      ]
+    },
     {
       "id": "arithmetic/scriptnum-constant-mul",
       "name": "ScriptNum constant multiplication",

--- a/knowledge/comparisons/ciphers.md
+++ b/knowledge/comparisons/ciphers.md
@@ -3,6 +3,7 @@
 | Construction | Block/key | Script bytes | Witness bytes | Peak items |
 | --- | --- | ---: | ---: | ---: |
 | PRINCEv2 u4 | 64-bit block / embedded 128-bit key | 6,136 | 17–33 | 633 |
+| PRINCEv2 standalone M-hat | 16-nibble linear layer | 1,565 | 32–33 | 633 |
 | AES-128 u4 | 128-bit block / embedded 128-bit key | 25,388 | 33–65 | 908 |
 
 PRINCEv2 is smaller locally but is not a semantic replacement for AES-128.
@@ -13,3 +14,9 @@ and stack use; the published nonzero key is 6,292 bytes with a 685-item peak.
 Both have zero hints and 16 plaintext data items. Strict tapscript fixture
 execution is recorded; complete transaction/relay-policy validation is open.
 Protocol requirements and cryptographic assumptions dominate this choice.
+
+The standalone M-hat row is not an encryption alternative: it omits S-boxes,
+round constants, key whitening, and ShiftRows. It is a reusable linear fragment
+that clears the OP-019 5,000-byte sub-fragment target while retaining the full
+PRINCEv2 table scheduler. Its 633-item peak is unchanged because the packed
+lookup memory dominates the four-state transformation.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -6,7 +6,7 @@ reproducible constructions. The local Rust library is one source of evidence;
 it is not the boundary of the atlas.
 
 The catalog is explicitly time-scoped. Its current review date is
-**2026-09-04**. A record's `as_of` field says when its claims were last checked.
+**2026-09-10**. A record's `as_of` field says when its claims were last checked.
 Missing records are unknown coverage, not proof of nonexistence.
 
 ## How to answer a research question

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -7,8 +7,11 @@ universal impossibility proofs.
 
 The [PRINCEv2 layout search](princev2-layout.md) records the discarded shared
 final-selector variant, invalid fixed-address row-removal experiment, and
-bounded global scheduling/CNOT searches. The retained result is a 6,136-byte
-zero-key fragment with zero hints and a strict 633-item combined peak.
+bounded global scheduling/CNOT searches. The retained full encryption result is
+a 6,136-byte zero-key fragment with zero hints and a strict 633-item combined
+peak. A standalone packed M-hat fragment now measures 1,565 bytes, but it does
+not replace the complete encryption circuit or prove that the rejected layout
+variants improve the full keyed construction.
 
 ## NR-001: Raw 1,024-byte SHAKE256 output exceeds the stack limit
 

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -15,6 +15,14 @@ The current zero-key baseline is 6,136 bytes and a 633-item peak. Table packing
 and algebraic sketches without a priced executable circuit do not satisfy
 this criterion; see [the layout search](negative-results/princev2-layout.md).
 
+Progress: the reusable standalone `prince_m_layer()` fragment now measures
+1,565 policy-produced bytes with 16 input data items, zero hints, and a strict
+633-item peak. It includes numeric nibble checks, packed table setup/cleanup,
+all four M-hat blocks, and output restoration. This clears the byte target for
+the linear-layer fragment, but does not yet demonstrate the complete
+generation-time-key encryption circuit against the pinned C fixtures and seeded
+random key/plaintext set, so OP-019 remains open.
+
 ## OP-001 — Strict execution matrix
 
 Add explicit legacy/P2WSH/tapscript strict and research-unlimited execution

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -38,6 +38,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [SHAKE256 over byte lanes](shake256-byte.md)
 - [AES-128 over u4 digits](aes128-u4.md)
 - [PRINCEv2 over u4 digits](princev2-u4.md)
+- [PRINCEv2 standalone M-hat layer](princev2-mhat.md)
 
 ## Signatures and one-time authentication
 

--- a/knowledge/primitives/princev2-mhat.md
+++ b/knowledge/primitives/princev2-mhat.md
@@ -1,0 +1,73 @@
+# PRINCEv2 standalone M-hat layer
+
+## Research question
+
+Can PRINCEv2's four repeated M-hat blocks be exposed as a reusable Bitcoin
+Script fragment below the OP-019 5,000-byte frontier while retaining strict
+stack execution and zero auxiliary hints?
+
+## Construction
+
+`prince_m_layer()` consumes the 16 MSB-first u4 state nibbles used by
+`prince_encrypt()` and returns the transformed 16-nibble state in the same
+order. It first checks every numeric input is in `0..=15`, then reuses the
+packed lookup memory and quartet scheduler already used by the optimized
+PRINCEv2 generator. It omits key whitening, S-boxes, round constants, and
+ShiftRows. The transformation is the PRINCEv2 M-layer and is an involution.
+
+The fragment preserves unrelated stack items below the 16-state input. It
+does not enforce minimally encoded witness bytes; callers that require a
+canonical wire encoding must add that policy at the surrounding boundary.
+
+## Measured boundary
+
+The `fragment-with-memory` boundary includes numeric range checks, packed table
+setup, all four M-hat blocks, output ordering, and table cleanup. It excludes
+input pushes, output consumption, tapleaf/control-block bytes, and transaction
+framing. The representative witness contains 16 nibble data items and zero
+auxiliary hints; all data items coexist at entry.
+
+| Configuration | Script bytes | Witness bytes | Hints | Peak items | Static non-push opcodes |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Zero-key packed layout, state `0x0123456789abcdef` | 1,565 | 32 (33 max) | 0 | 633 | 827 |
+
+The local executor reported no useful dynamic opcode count for this run, so
+static non-push operations are reported separately. The measured validation
+weight delta was zero. The result is `locally-reproduced` in a tapscript
+fixture with the combined 1,000-item stack limit enabled and remains
+`unclassified` for deployment.
+
+## Correctness and adversarial coverage
+
+Deterministic tests compare zero, all-nibble-maximum, and
+`0x0123456789abcdef` states against the native PRINCEv2 M-layer reference.
+They also reject an out-of-range nibble, a negative ScriptNum, and a short
+state. The benchmark executes the representative state under the strict local
+interpreter and reports the same boundary metrics.
+
+## Comparison and limitation
+
+The complete zero-key PRINCEv2 encryption fragment is 6,136 bytes and has the
+same measured 633-item peak. The standalone linear layer is therefore below
+the OP-019 5,000-byte fragment target, but it is not an encryption leaf and
+does not close the full-key/full-plaintext differential criterion. Complete
+transaction, Bitcoin Core, relay-policy, and canonical-byte validation remain
+open.
+
+## Reproduction
+
+```sh
+cargo test --locked optimized_m_layer --lib
+cargo test --locked --test primitive_metrics prince_metrics_are_current
+cargo run --locked --release --example prince_m_layer_benchmark
+```
+
+## Provenance
+
+- PRINCEv2 reference: `princev2-reference`, pinned to the repository's
+  immutable C revision in `knowledge/references/sources.json`.
+- Script compilation: the locked `rust-bitcoin-script` revision through
+  `ScriptCompilation::compile_with_policy()`.
+- Execution: the locked `bitcoin-scriptexec` revision in tapscript mode with
+  the combined stack limit enabled.
+

--- a/knowledge/primitives/princev2-u4.md
+++ b/knowledge/primitives/princev2-u4.md
@@ -27,3 +27,8 @@ differential test targets avoid the expensive full-repository metric suite.
 
 See the [implementation README](../../src/ciphers/prince/README.md) and catalog
 record `cipher/princev2-u4`.
+
+The reusable linear subconstruction is documented separately as the
+[standalone M-hat layer](princev2-mhat.md). It is a 1,565-byte checked fragment
+with the same measured 633-item peak, not a replacement for full PRINCEv2
+encryption.

--- a/research/prince-mhat/README.md
+++ b/research/prince-mhat/README.md
@@ -1,0 +1,43 @@
+# Standalone PRINCEv2 M-hat experiment
+
+## Question
+
+Can the repeated four-block PRINCEv2 M-hat layer be exposed as a reusable
+checked Script fragment below 5,000 policy-produced bytes without auxiliary
+hints or exceeding the strict 1,000-item tapscript stack limit?
+
+## Hypothesis and comparison
+
+The full zero-key PRINCEv2 fragment is 6,136 bytes because it repeats M-hat
+inside S-box, key, round-constant, and ShiftRows logic. Reusing its packed
+table layout and stack scheduler while removing those unrelated actions should
+leave a much smaller linear-layer fragment. The closest retained comparison is
+the complete zero-key encryption fragment; the old fresh-pair-table helper is a
+test-only baseline and is not a composable production construction.
+
+## Boundary and threat model
+
+The measured boundary is `fragment-with-memory`: numeric `0..=15` checks,
+packed lookup setup, four M-hat blocks, output restoration, and cleanup. It
+excludes input pushes, output consumption, transaction framing, and unrelated
+live state. Witness input is hostile numeric ScriptNum data; range failures,
+negative values, and missing state items must fail before lookup depths are
+used. Minimally encoded byte serialization is a caller-level obligation.
+
+## Result
+
+The fragment is 1,565 bytes, uses 16 data items and zero hints, reaches a
+strict 633-item combined peak, and has 827 static non-push operations. The
+local executor reports no useful dynamic opcode count for this run. The
+result is `locally-reproduced` and `unclassified` for deployment; it is a
+linear subconstruction, not a complete encryption proof.
+
+## Reproduction
+
+```sh
+cargo test --locked optimized_m_layer --lib
+cargo test --locked --test primitive_metrics prince_metrics_are_current
+cargo run --locked --release --example prince_m_layer_benchmark
+python3 tools/kb.py validate
+```
+

--- a/src/ciphers/prince/README.md
+++ b/src/ciphers/prince/README.md
@@ -22,10 +22,35 @@ including item count/lengths; it excludes the tapleaf and control block.
 | Fragment | Script size |
 | --- | ---: |
 | `prince_encrypt(0)` | <!-- metric:prince_encrypt -->6136<!-- /metric:prince_encrypt --> bytes |
+| Standalone `prince_m_layer()` | <!-- metric:prince_m_layer -->1565<!-- /metric:prince_m_layer --> bytes |
 | Plaintext witness, all-zero block | <!-- metric:prince_witness_min -->17<!-- /metric:prince_witness_min --> bytes |
 | Plaintext witness, no zero nibbles | <!-- metric:prince_witness_max -->33<!-- /metric:prince_witness_max --> bytes |
 | Maximum combined main/alt-stack depth | <!-- metric:prince_stack -->633<!-- /metric:prince_stack --> items |
 | Fragment non-push operations | <!-- metric:prince_non_push_ops -->3988<!-- /metric:prince_non_push_ops --> |
+
+The standalone M-layer has a **fragment-with-memory** boundary that includes
+numeric nibble-range checks, packed lookup setup, all four M-hat blocks, output
+ordering, and cleanup. It excludes input pushes, output consumption, and
+transaction framing. Its representative witness has 16 nibble data items,
+32 serialized bytes, and zero auxiliary hints; the strict combined peak is
+<!-- metric:prince_m_layer_stack -->633<!-- /metric:prince_m_layer_stack --> items
+and the fragment has
+<!-- metric:prince_m_layer_static_opcodes -->827<!-- /metric:prince_m_layer_static_opcodes --> static non-push operations.
+The local executor does not expose a useful dynamic opcode count for this
+fragment, so the static count is reported separately. The fragment is below
+the OP-019 5,000-byte target, but it is a reusable linear layer rather than a
+complete encryption leaf.
+
+The standalone M-layer uses the zero-key generator's packed table layout and
+stack scheduler without embedding key or S-box actions. `prince_m_layer()`
+certifies numeric inputs in `0..=15` before using them as lookup-derived stack
+depths, but does not enforce minimally encoded witness bytes. The transformation
+is an involution under the PRINCEv2 reference matrix; callers must still consume
+all 16 output nibbles and leave a clean terminal result.
+
+The M-layer's representative witness contains
+<!-- metric:prince_m_layer_witness -->32<!-- /metric:prince_m_layer_witness --> serialized bytes and
+<!-- metric:prince_m_layer_hints -->0<!-- /metric:prince_m_layer_hints --> auxiliary hint items.
 
 The zero-key fragment is 6,136 bytes, down from the previous 6,277 bytes
 (141 bytes / 2.25%). The published-vector key now costs 6,292 instead of

--- a/src/ciphers/prince/mod.rs
+++ b/src/ciphers/prince/mod.rs
@@ -1085,6 +1085,7 @@ mod optimized {
 
     #[derive(Clone, Copy)]
     enum PreAction {
+        None,
         Initial,
         Forward(usize),
         MiddleForward,
@@ -1438,6 +1439,7 @@ mod optimized {
 
         fn emit_pre_action(&self, action: PreAction, state: usize) -> Program {
             match action {
+                PreAction::None => Program::default(),
                 PreAction::Initial => self.op_sbox_xor_constant(self.key[state], 0),
                 PreAction::Forward(round) => {
                     let key_index = if (round - 1) % 2 != 0 {
@@ -1671,6 +1673,33 @@ mod optimized {
         }
     }
 
+    pub(super) fn m_layer_engine() -> Script {
+        let mut generator = Generator::new(0);
+        let mut out = generator.init_memory();
+        out.extend(generator.m_layer(PreAction::None));
+
+        // Retire the transformed state, drop persistent lookup memory, and
+        // restore the public MSB-on-top order.
+        let mut remaining = env_top_order(&generator.env);
+        for state in (0..SIZE_STATE).rev() {
+            let moved = move_state_in_order(&remaining, state);
+            out.extend(moved.emit);
+            out.op(OP_TOALTSTACK);
+            remaining = moved.order;
+            remaining.remove(0);
+        }
+        for _ in 0..(generator.tables.memory_size - SIZE_STATE) / 2 {
+            out.op(OP_2DROP);
+        }
+        if (generator.tables.memory_size - SIZE_STATE) & 1 != 0 {
+            out.op(OP_DROP);
+        }
+        for _ in 0..SIZE_STATE {
+            out.op(OP_FROMALTSTACK);
+        }
+        Script::new("PRINCEv2 M-layer").push_script(out.into_script_buf())
+    }
+
     static ENGINES: OnceLock<Mutex<HashMap<u128, ScriptBuf>>> = OnceLock::new();
 
     pub(super) fn engine(key: u128) -> Script {
@@ -1697,6 +1726,32 @@ pub fn prince_encrypt(key: u128) -> Script {
     optimized::engine(key)
 }
 
+/// PRINCEv2's four M-hat blocks over a 16-nibble state.
+///
+/// Input and output use the same MSB-first stack layout as `prince_encrypt`.
+/// The 16 top state items must be numeric nibbles in `0..=15`; unrelated
+/// stack items below them are preserved.
+pub fn prince_m_layer() -> Script {
+    script! {
+        // Certify the nibble domain before any table-derived depth is used.
+        for _ in 0..16 {
+            OP_TOALTSTACK
+        }
+        for _ in 0..16 {
+            OP_FROMALTSTACK
+            OP_DUP
+            0 OP_LESSTHAN OP_NOT OP_VERIFY
+            OP_DUP
+            16 OP_LESSTHAN OP_VERIFY
+            OP_TOALTSTACK
+        }
+        for _ in 0..16 {
+            OP_FROMALTSTACK
+        }
+        { optimized::m_layer_engine() }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helper: u64 with MSB nibble first ↔ nibble array
 // nibble[i] = get_nibble(v, i) = (v >> (4*(15-i))) & 0xf
@@ -1717,7 +1772,7 @@ pub fn u64_to_nibbles_msb(v: u64) -> [u8; 16] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::support::execution::execute_script;
+    use crate::support::execution::{execute_script, execute_script_with_inputs_strict};
     use crate::support::script::{script, ScriptCompilation};
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
@@ -1924,6 +1979,57 @@ mod tests {
             "script_m_layer failed: expected {:?}, error={:?}",
             exp_nibs, result.error
         );
+    }
+
+    fn m_layer_witness(state: u64) -> Vec<Vec<u8>> {
+        u64_to_nibbles_msb(state)
+            .into_iter()
+            .rev()
+            .map(|nibble| if nibble == 0 { vec![] } else { vec![nibble] })
+            .collect()
+    }
+
+    #[test]
+    fn test_optimized_m_layer_boundaries_and_random_state() {
+        let fragment = prince_m_layer();
+        for state in [0, u64::MAX, 0x0123_4567_89ab_cdef] {
+            let expected = m_layer(state);
+            let expected_nibbles = u64_to_nibbles_msb(expected);
+            let leaf = script! {
+                { fragment.clone() }
+                for nibble in expected_nibbles {
+                    { nibble as u32 } OP_EQUALVERIFY
+                }
+                OP_TRUE
+            };
+            let result = execute_script_with_inputs_strict(leaf, m_layer_witness(state));
+            assert!(result.success, "state={state:016x}: {result}");
+            assert!(result.stats.max_nb_stack_items <= 1_000);
+        }
+    }
+
+    #[test]
+    fn test_optimized_m_layer_rejects_invalid_nibbles_and_short_input() {
+        let fragment = prince_m_layer();
+        let too_large = {
+            let mut witness = m_layer_witness(0);
+            witness[15] = vec![16];
+            witness
+        };
+        let negative = {
+            let mut witness = m_layer_witness(0);
+            witness[15] = vec![0x81];
+            witness
+        };
+        for witness in [too_large, negative] {
+            let result = execute_script_with_inputs_strict(fragment.clone(), witness);
+            assert!(!result.success, "invalid nibble was accepted: {result}");
+        }
+
+        let mut short = m_layer_witness(0);
+        short.pop();
+        let result = execute_script_with_inputs_strict(fragment, short);
+        assert!(!result.success, "short state was accepted: {result}");
     }
 
     #[test]

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -139,6 +139,62 @@ fn prince_metrics() -> Vec<Metric> {
     ]
 }
 
+fn prince_m_layer_metrics() -> Vec<Metric> {
+    let fragment = prince::prince_m_layer();
+    let compiled = fragment.clone().compile_with_policy();
+    let witness: Vec<Vec<u8>> = [
+        0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf,
+    ]
+    .into_iter()
+    .rev()
+    .map(|nibble| if nibble == 0 { vec![] } else { vec![nibble] })
+    .collect();
+    let execution_leaf = script! {
+        { fragment.clone() }
+        for _ in 0..8 { OP_2DROP }
+        OP_TRUE
+    };
+    let execution = execute_script_with_inputs_strict(execution_leaf, witness.clone());
+    assert!(
+        execution.success,
+        "PRINCEv2 M-layer metric execution failed: {execution}"
+    );
+    let static_non_push = compiled
+        .instructions()
+        .map(|instruction| instruction.expect("generated PRINCEv2 M-layer must parse"))
+        .filter(
+            |instruction| matches!(instruction, Instruction::Op(opcode) if opcode.to_u8() > 0x60),
+        )
+        .count();
+    vec![
+        Metric {
+            readme: "src/ciphers/prince/README.md",
+            key: "prince_m_layer",
+            value: compiled.len(),
+        },
+        Metric {
+            readme: "src/ciphers/prince/README.md",
+            key: "prince_m_layer_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/ciphers/prince/README.md",
+            key: "prince_m_layer_stack",
+            value: execution.stats.max_nb_stack_items,
+        },
+        Metric {
+            readme: "src/ciphers/prince/README.md",
+            key: "prince_m_layer_static_opcodes",
+            value: static_non_push,
+        },
+        Metric {
+            readme: "src/ciphers/prince/README.md",
+            key: "prince_m_layer_hints",
+            value: 0,
+        },
+    ]
+}
+
 // Summary columns stay in the overview; detailed snapshots live with their construction.
 fn winternitz_metric_readme(key: &str) -> &'static str {
     if key.starts_with("w20_") {
@@ -3988,6 +4044,7 @@ fn metrics() -> Vec<Metric> {
     ]
     .into_iter()
     .chain(prince_metrics())
+    .chain(prince_m_layer_metrics())
     .chain(winternitz_metrics())
     .chain(winternitz_sha256_metrics())
     .chain(winternitz_preimage16_metrics())
@@ -4034,7 +4091,12 @@ fn winternitz20_metrics_are_current() {
 /// generating scripts for the full-repository metric suite.
 #[test]
 fn prince_metrics_are_current() {
-    check_readme_metrics(prince_metrics());
+    check_readme_metrics(
+        prince_metrics()
+            .into_iter()
+            .chain(prince_m_layer_metrics())
+            .collect(),
+    );
 }
 
 /// This isolated fixture exercises only the two small packed decoders. It


### PR DESCRIPTION
## Summary

- expose PRINCEv2's four-block M-hat linear layer as `prince_m_layer()`
- reuse the packed table layout and stack scheduler without key/S-box actions
- range-check all 16 numeric nibble inputs before lookup-derived stack depths
- add deterministic boundary, invalid-input, short-input, benchmark, metrics, and knowledge-base coverage

## Measured boundary

`fragment-with-memory` includes nibble checks, packed lookup setup, all four M-hat blocks, output restoration, and cleanup. It excludes input pushes, output consumption, transaction framing, and unrelated live state.

- policy-produced locking fragment: 1,565 bytes
- representative witness: 32 bytes, 33-byte maximum
- input data items: 16
- auxiliary hints: 0
- strict combined stack peak: 633 items
- static non-push opcodes: 827
- local dynamic opcode count: unavailable

This is a reusable PRINCEv2 linear layer, not a complete encryption leaf. It clears the OP-019 5,000-byte M-hat sub-fragment target; full generation-time-key encryption remains 6,136 bytes and OP-019 remains open for complete fixture/differential evidence.

## Focused verification

- `cargo test --locked optimized_m_layer --lib`
- `cargo test --locked test_prince_script_encrypt --lib`
- `cargo test --locked --test primitive_metrics prince_metrics_are_current`
- `cargo test --locked --test knowledge_base`
- `cargo run --locked --release --example prince_m_layer_benchmark`
- `python3 tools/kb.py validate`
- `cargo fmt --all -- --check`
- `git diff --check`

The full repository test suite was not run; verification was limited to the affected PRINCEv2 primitive, its metrics/benchmark, catalog validation, formatting, and a focused existing encryption regression.
