### PR TITLE
feat(arithmetic): add compressed u32 addition

### DIFF
--- a/examples/u32_compressed_add_benchmark.rs
+++ b/examples/u32_compressed_add_benchmark.rs
@@ -1,0 +1,93 @@
+use bitcoin::consensus::encode::serialize;
+use bitcoin::{script::Instruction, Witness};
+use bitcoin_lab::{
+    arithmetic::u32::{add::u32_add_drop, add::u32_compressed_add, stack::u32_drop},
+    support::{execution::execute_script_with_inputs_strict, script::ScriptCompilation},
+};
+use bitcoin_script::script;
+
+fn scriptnum(value: u32) -> Vec<u8> {
+    let mut bytes = [0u8; 8];
+    let length = bitcoin::script::write_scriptint(&mut bytes, i64::from(value as i32));
+    bytes[..length].to_vec()
+}
+
+fn word_items(value: u32) -> [Vec<u8>; 4] {
+    [
+        scriptnum(value >> 24),
+        scriptnum((value >> 16) & 0xff),
+        scriptnum((value >> 8) & 0xff),
+        scriptnum(value & 0xff),
+    ]
+}
+
+fn static_non_push(script: &bitcoin_script::Script) -> usize {
+    script
+        .clone()
+        .compile_with_policy()
+        .instructions()
+        .map(|instruction| instruction.expect("generated fragment must parse"))
+        .filter(
+            |instruction| matches!(instruction, Instruction::Op(opcode) if opcode.to_u8() > 0x60),
+        )
+        .count()
+}
+
+fn main() {
+    let a = 0xa5c3_19e7;
+    let b = 0x1234_5678;
+    let compressed = u32_compressed_add();
+    let byte_baseline = u32_add_drop(0, 1);
+    let compressed_witness = vec![scriptnum(b), scriptnum(a)];
+    let a_items = word_items(a);
+    let b_items = word_items(b);
+    let byte_witness = b_items.into_iter().chain(a_items).collect::<Vec<_>>();
+    let compressed_leaf = script! {
+        { compressed.clone() }
+        OP_DROP
+        OP_TRUE
+    };
+    let byte_leaf = script! {
+        { byte_baseline.clone() }
+        { u32_drop() }
+        OP_TRUE
+    };
+    let compressed_result =
+        execute_script_with_inputs_strict(compressed_leaf, compressed_witness.clone());
+    let byte_result = execute_script_with_inputs_strict(byte_leaf, byte_witness.clone());
+    assert!(
+        compressed_result.success,
+        "compressed add failed: {compressed_result}"
+    );
+    assert!(byte_result.success, "byte add failed: {byte_result}");
+
+    for (name, fragment, witness, result) in [
+        (
+            "compressed",
+            compressed,
+            compressed_witness,
+            compressed_result,
+        ),
+        ("byte_baseline", byte_baseline, byte_witness, byte_result),
+    ] {
+        let compiled = fragment.clone().compile_with_policy();
+        println!("{name}_script_bytes={}", compiled.len());
+        println!(
+            "{name}_witness_bytes={}",
+            serialize(&Witness::from_slice(&witness)).len()
+        );
+        println!("{name}_witness_data_items={}", witness.len());
+        println!("{name}_hint_items=0");
+        println!("{name}_stack_peak={}", result.stats.max_nb_stack_items);
+        println!("{name}_executed_opcodes={}", result.stats.opcode_count);
+        println!(
+            "{name}_static_non_push_opcodes={}",
+            static_non_push(&fragment)
+        );
+        println!(
+            "{name}_validation_weight_delta={}",
+            result.stats.start_validation_weight - result.stats.validation_weight
+        );
+    }
+    println!("context=tapscript stack_limit=1000");
+}

--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1,8 +1,76 @@
 {
   "schema_version": 1,
-  "as_of": "2026-09-01",
+  "as_of": "2026-09-10",
   "cost_model": "knowledge/cost-model.md",
   "records": [
+    {
+      "id": "arithmetic/u32-compressed-add",
+      "name": "Compressed total-domain u32 addition",
+      "class": "arithmetic/word",
+      "summary": "Canonical two-item ScriptNum wire adapter for modulo-2^32 addition.",
+      "status": "experimental",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-10",
+      "knowledge_page": "knowledge/primitives/u32-compressed-add.md",
+      "implementation": "src/arithmetic/u32/add.rs",
+      "documentation": "src/arithmetic/u32/README.md",
+      "tests": [
+        "arithmetic::u32::add::test::test_compressed_add_boundaries_and_random_values",
+        "arithmetic::u32::add::test::test_compressed_add_rejects_noncanonical_inputs",
+        "primitive_metrics::u32_compressed_add_metrics_are_current",
+        "examples/u32_compressed_add_benchmark.rs"
+      ],
+      "references": [
+        "bip-342",
+        "bitcoin-script-locked",
+        "bitcoin-scriptexec-locked"
+      ],
+      "techniques": [
+        "compact-wire",
+        "carry-arithmetic",
+        "canonical-encoding"
+      ],
+      "security": "No independent cryptographic claim. Both compressed words are hostile and must pass exact canonical-wire checks before expansion; complete protocol binding and deployment validation remain open.",
+      "stack_contract": "... word_b word_a -> ... compressed(word_a + word_b mod 2^32); both inputs are consumed and unrelated lower stack state is preserved.",
+      "configurations": [
+        {
+          "id": "representative-a5c319e7-plus-12345678",
+          "label": "Compressed addition versus four-byte baseline",
+          "parameters": {
+            "a": "0xa5c319e7",
+            "b": "0x12345678",
+            "modulus": "2^32",
+            "hint_items_per_invocation": 0,
+            "complete_input_items": 2
+          },
+          "includes": "fragment-with-memory: two canonical-wire checks, two u32 expansions, byte carry addition, and canonical recompression; excludes input pushes, terminal predicate, transaction framing, and unrelated live state",
+          "script_bytes": 1016,
+          "witness_bytes": 11,
+          "witness_bytes_max": 13,
+          "max_stack_items": 11,
+          "executed_opcodes": null,
+          "validation_weight": 0,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 1016,
+          "metric_keys": [
+            "u32_compressed_add",
+            "u32_compressed_add_witness",
+            "u32_compressed_add_witness_max",
+            "u32_compressed_add_stack"
+          ]
+        }
+      ],
+      "limitations": [
+        "Dominated by the four-byte baseline for locking-script bytes and combined local cost",
+        "Dynamic opcode count is unavailable from the local executor",
+        "Bitcoin Core, complete-transaction, relay-policy, and canonical witness-policy validation remain open"
+      ],
+      "open_problems": [
+        "OP-002",
+        "OP-003"
+      ]
+    },
     {
       "id": "arithmetic/scriptnum-constant-mul",
       "name": "ScriptNum constant multiplication",

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Compressed total-domain u32 addition | two-item compressed wire | 1,016 | 11-byte representative witness; byte baseline is 78 bytes and 20-byte witness |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |
@@ -33,6 +34,12 @@ but longer expressions remain modular unless their bound is proved below its
 513-bit composite modulus. Range checks and conversion remain outside a row
 unless its boundary says otherwise; terminal predicates remain excluded from
 both modular-product rows.
+
+The compressed u32 addition row is a deliberate witness-width tradeoff: it
+saves nine representative witness bytes and six entry items, but expands to
+the byte carry chain and costs 1,016 locking bytes versus 78 for the ordinary
+adder. It is retained for witness-constrained composition, not as a general
+locking-byte winner.
 
 The 9,893-byte Ed25519 row is the current locking-script-size winner for this
 field. It keeps host values in the ordinary field domain but uses a unique

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -6,7 +6,7 @@ reproducible constructions. The local Rust library is one source of evidence;
 it is not the boundary of the atlas.
 
 The catalog is explicitly time-scoped. Its current review date is
-**2026-09-04**. A record's `as_of` field says when its claims were last checked.
+**2026-09-10**. A record's `as_of` field says when its claims were last checked.
 Missing records are unknown coverage, not proof of nonexistence.
 
 ## How to answer a research question

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,14 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+
+## NR-043: Compressed u32 addition loses locking bytes
+
+The canonical compressed ScriptNum adapter for modulo-`2^32` addition measures
+1,016 locking bytes, 11 representative witness bytes, and an 11-item strict
+peak. The ordinary four-byte carry chain measures 78 locking bytes, 20 witness
+bytes, and a 10-item peak at the same two-word boundary. The compressed form
+saves nine witness bytes and six entry items, but adds 938 locking bytes and is
+dominated whenever script size or combined local cost is primary. It remains a
+locally reproduced option for protocols whose binding constraint is witness
+width; this is not a universal lower-bound claim.

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -10,6 +10,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [Hinted ScriptNum division](scriptnum-hinted-div.md)
 - [u4 digit arithmetic](u4.md)
 - [u32 word arithmetic](u32.md)
+- [Compressed total-domain u32 addition](u32-compressed-add.md)
 - [u31 prime-field arithmetic](u31.md)
 - [Native secp256k1 base-field arithmetic](secp256k1-field.md)
 - [Ed25519 base-field multiplication](ed25519-field.md)

--- a/knowledge/primitives/u32-compressed-add.md
+++ b/knowledge/primitives/u32-compressed-add.md
@@ -1,0 +1,57 @@
+# Compressed total-domain u32 addition
+
+## Research question
+
+Can the existing four-byte u32 carry chain be exposed over two canonical
+compressed ScriptNum words without losing total-domain correctness at the
+`0x80000000` sentinel and malformed-input boundaries?
+
+## Construction and threat model
+
+`u32_compressed_add()` consumes the top two compressed u32 ScriptNums, checks
+their exact canonical wire encodings, expands them with `u32_uncompress()`,
+reuses `u32_add_drop()` for modulo-`2^32` addition, and recompresses the result.
+The result is one canonical compressed ScriptNum. The two inputs are hostile;
+non-minimal aliases, negative zero, wrong five-byte values, and malformed
+widths are rejected before expansion. The operation preserves unrelated items
+below its two input words, subject to the documented altstack composition
+boundary.
+
+## Comparison objective and boundary
+
+The objective is serialized witness width and entry-item count, compared with
+the existing four-byte `u32_add_drop(0, 1)` under the same two-word operation
+and terminal cleanup. The `fragment-with-memory` boundary includes both wire
+certificates, expansion, the byte carry chain, and recompression; it excludes
+input pushes, witness serialization from locking-script bytes, terminal
+predicates, and transaction framing.
+
+| Construction | Script bytes | Representative witness | Maximum witness | Data items | Peak items | Static non-push opcodes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Compressed ScriptNum add | 1,016 | 11 | 13 | 2 | 11 | 765 |
+| Four-byte baseline | 78 | 20 | 20 | 8 | 10 | 51 |
+
+The compressed form saves nine representative witness bytes and six entry
+items, but costs 938 more locking bytes and one stack item. It is therefore a
+witness-width primitive, not a general byte-size improvement. The local
+executor reports no useful dynamic opcode count; validation-weight delta is
+zero in the strict tapscript fixture.
+
+## Evidence and execution class
+
+Evidence is `locally-reproduced`; deployment is `unclassified`. Deterministic
+tests cover zero, carry, wraparound, signed-boundary, and all-ones cases plus
+64 pairs from the fixed ChaCha20 seed `0x43304144`. Adversarial tests reject non-minimal one,
+negative zero, an invalid five-byte value, and a non-minimal second operand.
+The strict fixture uses the locked `bitcoin-scriptexec` revision in tapscript
+mode with the combined 1,000-item stack limit enabled. No Bitcoin Core,
+complete-transaction, relay-policy, or cryptographic claim is made.
+
+## Reproduction
+
+```sh
+cargo test --locked compressed_add --lib
+cargo test --locked --test primitive_metrics u32_compressed_add_metrics_are_current
+cargo run --locked --release --example u32_compressed_add_benchmark
+python3 tools/kb.py validate
+```

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -15,3 +15,8 @@ stack manipulation.
 See the [implementation README](../../src/arithmetic/u32/README.md),
 [technique page](../techniques/representations.md), and catalog record
 `arithmetic/u32`.
+
+The compressed-wire addition experiment is documented separately in
+[compressed total-domain u32 addition](u32-compressed-add.md). It saves witness
+width but is dominated for locking-script bytes by the ordinary byte-word
+adder.

--- a/research/u32-compressed-add/README.md
+++ b/research/u32-compressed-add/README.md
@@ -1,0 +1,30 @@
+# Compressed u32 addition experiment
+
+## Question
+
+Does a canonical one-item ScriptNum wire reduce witness and entry-stack cost
+enough to justify wrapping the existing byte-oriented modulo-`2^32` adder?
+
+## Hypothesis
+
+The compressed form should remove six of the eight byte-word data items and
+reduce witness serialization, but its two full ScriptNum expanders and
+canonicality checks should dominate locking-script bytes.
+
+## Result
+
+At `0xa5c319e7 + 0x12345678`, compressed addition is 1,016 script bytes,
+11 witness bytes, 2 data items, and an 11-item strict peak. The four-byte
+baseline is 78 script bytes, 20 witness bytes, 8 data items, and a 10-item
+peak. Dynamic opcode counting is unavailable; the static counts are 765 and
+51 respectively. The compressed construction is thus useful only under a
+witness-width objective and is recorded as a dominated locking-byte tradeoff.
+
+## Reproduction
+
+```sh
+cargo test --locked compressed_add --lib
+cargo test --locked --test primitive_metrics u32_compressed_add_metrics_are_current
+cargo run --locked --release --example u32_compressed_add_benchmark
+```
+

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -32,6 +32,7 @@ as less-than-or-equal.
 | Fragment | Locking script | Auxiliary unlocking hints | Maximum main-stack depth |
 | --- | ---: | ---: | ---: |
 | `u32_add_drop(0, 1)` | <!-- metric:u32_add_drop -->78<!-- /metric:u32_add_drop --> bytes | 0 bytes | <!-- metric:u32_add_drop_stack -->10<!-- /metric:u32_add_drop_stack --> items |
+| `u32_compressed_add()` | <!-- metric:u32_compressed_add -->1016<!-- /metric:u32_compressed_add --> bytes | <!-- metric:u32_compressed_add_witness -->11<!-- /metric:u32_compressed_add_witness --> bytes (<!-- metric:u32_compressed_add_witness_max -->13<!-- /metric:u32_compressed_add_witness_max --> max) | <!-- metric:u32_compressed_add_stack -->11<!-- /metric:u32_compressed_add_stack --> items |
 | `u32_sub_drop(0, 1)` | <!-- metric:u32_sub_drop -->77<!-- /metric:u32_sub_drop --> bytes | 0 bytes | <!-- metric:u32_sub_drop_stack -->9<!-- /metric:u32_sub_drop_stack --> items |
 | `u32_lessthan()` | <!-- metric:u32_lessthan -->38<!-- /metric:u32_lessthan --> bytes | 0 bytes | <!-- metric:u32_lessthan_stack -->9<!-- /metric:u32_lessthan_stack --> items |
 | `u32_lessthanorequal()` | <!-- metric:u32_lessthanorequal -->61<!-- /metric:u32_lessthanorequal --> bytes | 0 bytes | <!-- metric:u32_lessthanorequal_stack -->13<!-- /metric:u32_lessthanorequal_stack --> items |
@@ -39,6 +40,27 @@ as less-than-or-equal.
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
+
+`u32_compressed_add()` is a checked wire adapter: it accepts two canonical
+compressed u32 ScriptNums, expands them through the existing byte carry chain,
+and returns the canonical compressed representation of the sum modulo `2^32`.
+The top word is added to the word below it. The representative boundary uses
+two data items and zero auxiliary hints; it includes both canonicality checks,
+expansion, byte addition, and recompression, but excludes witness pushes and a
+terminal predicate. The local strict fixture measures
+<!-- metric:u32_compressed_add_static_opcodes -->765<!-- /metric:u32_compressed_add_static_opcodes --> static non-push operations;
+dynamic opcode counting is unavailable in the local executor.
+
+This is a witness-width tradeoff, not a general byte-cost improvement. At the
+representative values it saves nine serialized witness bytes and six entry
+items versus the four-byte `u32_add_drop` baseline, but adds 938 locking bytes
+and one stack item. It is useful only when witness width or item count matters
+more than locking-script bytes. All compressed inputs are treated as hostile:
+non-minimal aliases, negative zero, wrong five-byte values, and malformed
+widths are rejected before expansion.
+The same representative byte baseline has
+<!-- metric:u32_add_drop_witness -->20<!-- /metric:u32_add_drop_witness --> serialized witness bytes and a
+<!-- metric:u32_add_drop_byte_stack -->10<!-- /metric:u32_add_drop_byte_stack --> item strict peak.
 
 Operand witness serialization is deliberately excluded: callers may construct
 words inside the locking script or supply four witness items per word. No

--- a/src/arithmetic/u32/add.rs
+++ b/src/arithmetic/u32/add.rs
@@ -1,3 +1,4 @@
+use crate::arithmetic::u32::stack::{u32_compress, u32_uncompress};
 use crate::arithmetic::u32::zip::{u32_copy_zip, u32_zip};
 use crate::support::script::*;
 
@@ -103,17 +104,75 @@ pub fn u32_add_drop(a: u32, b: u32) -> Script {
     }
 }
 
+fn certify_compressed_word() -> Script {
+    script! {
+        OP_DUP
+        OP_SIZE
+        5
+        OP_EQUAL
+        OP_IF
+            -2147483648
+            OP_EQUALVERIFY
+        OP_ELSE
+            OP_DUP
+            0
+            OP_ADD
+            OP_EQUALVERIFY
+        OP_ENDIF
+    }
+}
+
+/// Adds two canonical compressed u32 ScriptNums modulo `2^32`.
+///
+/// The top compressed word is added to the compressed word below it. Both
+/// inputs are consumed and one canonical compressed result is returned.
+pub fn u32_compressed_add() -> Script {
+    script! {
+        { certify_compressed_word() }
+        OP_TOALTSTACK
+        { certify_compressed_word() }
+        { u32_uncompress() }
+        OP_FROMALTSTACK
+        { u32_uncompress() }
+        { u32_add_drop(0, 1) }
+        { u32_compress() }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::arithmetic::u32::stack::{u32_equal, u32_equalverify, u32_push};
-    use crate::support::execution::run;
-    use rand::Rng;
+    use crate::support::execution::{execute_script_with_inputs_strict, run};
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha20Rng;
+
+    fn scriptnum(value: u32) -> Vec<u8> {
+        let mut bytes = [0u8; 8];
+        let length = bitcoin::script::write_scriptint(&mut bytes, i64::from(value as i32));
+        bytes[..length].to_vec()
+    }
+
+    fn check_compressed_add(a: u32, b: u32) {
+        let expected = a.wrapping_add(b);
+        let result = execute_script_with_inputs_strict(
+            script! {
+                { u32_compressed_add() }
+                { i64::from(expected as i32) }
+                OP_EQUAL
+            },
+            vec![scriptnum(b), scriptnum(a)],
+        );
+        assert!(
+            result.success,
+            "compressed add failed for {a:08x}+{b:08x}: {result}"
+        );
+    }
 
     #[test]
     fn test_u32_add() {
         println!("u32_len: {}", u32_add_drop(1, 0).len());
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha20Rng::seed_from_u64(0x4330_4144);
         for _ in 0..1000 {
             let x = rng.gen();
             let y = rng.gen_range(0..=u32::MAX - x);
@@ -163,6 +222,45 @@ mod test {
                 run(script_without_carry);
                 run(script_with_carry);
             }
+        }
+    }
+
+    #[test]
+    fn test_compressed_add_boundaries_and_random_values() {
+        for &(a, b) in &[
+            (0, 0),
+            (1, 1),
+            (0x7fff_ffff, 1),
+            (0x8000_0000, 0x8000_0000),
+            (u32::MAX, 1),
+            (0xffff_fffe, 3),
+        ] {
+            check_compressed_add(a, b);
+        }
+
+        let mut rng = rand::thread_rng();
+        for _ in 0..64 {
+            check_compressed_add(rng.gen(), rng.gen());
+        }
+    }
+
+    #[test]
+    fn test_compressed_add_rejects_noncanonical_inputs() {
+        let cases = [
+            vec![vec![1, 0], scriptnum(2)],
+            vec![vec![0, 0, 0, 0x80], scriptnum(2)],
+            vec![vec![1, 0, 0, 0, 0], scriptnum(2)],
+            vec![scriptnum(1), vec![2, 0]],
+        ];
+        for witness in cases {
+            let result = execute_script_with_inputs_strict(
+                script! {
+                    { u32_compressed_add() }
+                    OP_1
+                },
+                witness,
+            );
+            assert!(!result.success, "noncanonical input was accepted: {result}");
         }
     }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -93,6 +93,86 @@ fn max_stack_items_strict(script: bitcoin_script::Script, witness: Vec<Vec<u8>>)
     result.stats.max_nb_stack_items
 }
 
+fn compressed_u32_witness(value: u32) -> Vec<u8> {
+    scriptnum(i64::from(value as i32))
+}
+
+fn byte_u32_witness(value: u32) -> [Vec<u8>; 4] {
+    [
+        scriptnum(i64::from(value >> 24)),
+        scriptnum(i64::from((value >> 16) & 0xff)),
+        scriptnum(i64::from((value >> 8) & 0xff)),
+        scriptnum(i64::from(value & 0xff)),
+    ]
+}
+
+fn u32_compressed_add_metrics() -> Vec<Metric> {
+    const A: u32 = 0xa5c3_19e7;
+    const B: u32 = 0x1234_5678;
+    let compressed = u32::add::u32_compressed_add();
+    let byte_baseline = u32::add::u32_add_drop(0, 1);
+    let compressed_witness = vec![compressed_u32_witness(B), compressed_u32_witness(A)];
+    let byte_witness = byte_u32_witness(B)
+        .into_iter()
+        .chain(byte_u32_witness(A))
+        .collect::<Vec<_>>();
+    let compressed_stack = max_stack_items_strict(
+        script! {
+            { compressed.clone() }
+            OP_DROP OP_TRUE
+        },
+        compressed_witness.clone(),
+    );
+    let byte_stack = max_stack_items_strict(
+        script! {
+            { byte_baseline.clone() }
+            { u32::stack::u32_drop() }
+            OP_TRUE
+        },
+        byte_witness.clone(),
+    );
+    vec![
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_add",
+            value: script_len(compressed.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_add_witness",
+            value: witness_size(&compressed_witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_add_witness_max",
+            value: witness_size(&[
+                compressed_u32_witness(u32::from(0x80u8) << 24),
+                compressed_u32_witness(u32::from(0x80u8) << 24),
+            ]),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_add_stack",
+            value: compressed_stack,
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_add_static_opcodes",
+            value: static_non_push_opcodes(compressed),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_add_drop_witness",
+            value: witness_size(&byte_witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_add_drop_byte_stack",
+            value: byte_stack,
+        },
+    ]
+}
+
 fn prince_metrics() -> Vec<Metric> {
     let fragment = prince::prince_encrypt(0);
     let compiled = fragment.clone().compile_with_policy();
@@ -3987,6 +4067,7 @@ fn metrics() -> Vec<Metric> {
         },
     ]
     .into_iter()
+    .chain(u32_compressed_add_metrics())
     .chain(prince_metrics())
     .chain(winternitz_metrics())
     .chain(winternitz_sha256_metrics())
@@ -4035,6 +4116,11 @@ fn winternitz20_metrics_are_current() {
 #[test]
 fn prince_metrics_are_current() {
     check_readme_metrics(prince_metrics());
+}
+
+#[test]
+fn u32_compressed_add_metrics_are_current() {
+    check_readme_metrics(u32_compressed_add_metrics());
 }
 
 /// This isolated fixture exercises only the two small packed decoders. It


### PR DESCRIPTION
## Summary

- add `u32_compressed_add()` over two canonical compressed ScriptNum u32 words
- reuse the existing expansion, byte carry chain, and recompression helpers
- reject non-minimal aliases, negative zero, invalid five-byte values, and malformed inputs
- add deterministic boundary/random tests, strict metrics, benchmark output, and knowledge-base documentation

## Measured tradeoff

`fragment-with-memory` includes both canonical-wire checks, expansion, modulo-`2^32` byte addition, and recompression; it excludes input pushes, terminal predicates, transaction framing, and unrelated live state.

| Construction | Script | Representative witness | Max witness | Data items | Strict peak | Static non-push opcodes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Compressed ScriptNum add | 1,016 bytes | 11 bytes | 13 bytes | 2 | 11 | 765 |
| Four-byte baseline | 78 bytes | 20 bytes | 20 bytes | 8 | 10 | 51 |

This is a deliberate witness-width result: it saves nine representative witness bytes and six entry items, but costs 938 locking bytes and one stack item. It is recorded as NR-043 and is useful only when witness width dominates the objective.

## Focused verification

- `cargo test --locked compressed_add --lib`
- `cargo test --locked arithmetic::u32::add::test::test_u32_add --lib`
- `cargo test --locked --test primitive_metrics u32_compressed_add_metrics_are_current`
- `cargo test --locked --test knowledge_base`
- `cargo run --locked --release --example u32_compressed_add_benchmark`
- `python3 tools/kb.py validate`
- `cargo fmt --all -- --check`
- `git diff --check`

The full repository test suite was not run; verification was limited to the affected u32 addition path, its metrics/benchmark, catalog validation, formatting, and the existing focused adder regression.
