### PR TITLE
feat(arithmetic): add compressed u32 equality

### DIFF
--- a/examples/u32_compressed_equal_benchmark.rs
+++ b/examples/u32_compressed_equal_benchmark.rs
@@ -1,0 +1,91 @@
+use bitcoin::consensus::encode::serialize;
+use bitcoin::{script::Instruction, Witness};
+use bitcoin_lab::{
+    arithmetic::u32::stack::{u32_compressed_equal, u32_equal},
+    support::{execution::execute_script_with_inputs_strict, script::ScriptCompilation},
+};
+use bitcoin_script::script;
+
+fn scriptnum(value: u32) -> Vec<u8> {
+    let mut bytes = [0u8; 8];
+    let length = bitcoin::script::write_scriptint(&mut bytes, i64::from(value as i32));
+    bytes[..length].to_vec()
+}
+
+fn word_items(value: u32) -> [Vec<u8>; 4] {
+    [
+        scriptnum(value >> 24),
+        scriptnum((value >> 16) & 0xff),
+        scriptnum((value >> 8) & 0xff),
+        scriptnum(value & 0xff),
+    ]
+}
+
+fn static_non_push(script: &bitcoin_script::Script) -> usize {
+    script
+        .clone()
+        .compile_with_policy()
+        .instructions()
+        .map(|instruction| instruction.expect("generated fragment must parse"))
+        .filter(
+            |instruction| matches!(instruction, Instruction::Op(opcode) if opcode.to_u8() > 0x60),
+        )
+        .count()
+}
+
+fn main() {
+    let value = 0x0102_0304;
+    let compressed = u32_compressed_equal();
+    let byte_baseline = u32_equal();
+    let compressed_witness = vec![scriptnum(value), scriptnum(value)];
+    let items = word_items(value);
+    let byte_witness = items.clone().into_iter().chain(items).collect::<Vec<_>>();
+    let compressed_leaf = script! {
+        { compressed.clone() }
+        OP_VERIFY
+        OP_TRUE
+    };
+    let byte_leaf = script! {
+        { byte_baseline.clone() }
+        OP_VERIFY
+        OP_TRUE
+    };
+    let compressed_result =
+        execute_script_with_inputs_strict(compressed_leaf, compressed_witness.clone());
+    let byte_result = execute_script_with_inputs_strict(byte_leaf, byte_witness.clone());
+    assert!(
+        compressed_result.success,
+        "compressed equality failed: {compressed_result}"
+    );
+    assert!(byte_result.success, "byte equality failed: {byte_result}");
+
+    for (name, fragment, witness, result) in [
+        (
+            "compressed",
+            compressed,
+            compressed_witness,
+            compressed_result,
+        ),
+        ("byte_baseline", byte_baseline, byte_witness, byte_result),
+    ] {
+        let compiled = fragment.clone().compile_with_policy();
+        println!("{name}_script_bytes={}", compiled.len());
+        println!(
+            "{name}_witness_bytes={}",
+            serialize(&Witness::from_slice(&witness)).len()
+        );
+        println!("{name}_witness_data_items={}", witness.len());
+        println!("{name}_hint_items=0");
+        println!("{name}_stack_peak={}", result.stats.max_nb_stack_items);
+        println!("{name}_executed_opcodes={}", result.stats.opcode_count);
+        println!(
+            "{name}_static_non_push_opcodes={}",
+            static_non_push(&fragment)
+        );
+        println!(
+            "{name}_validation_weight_delta={}",
+            result.stats.start_validation_weight - result.stats.validation_weight
+        );
+    }
+    println!("context=tapscript stack_limit=1000");
+}

--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1,8 +1,94 @@
 {
   "schema_version": 1,
-  "as_of": "2026-09-01",
+  "as_of": "2026-09-10",
   "cost_model": "knowledge/cost-model.md",
   "records": [
+    {
+      "id": "arithmetic/u32-compressed-equal",
+      "name": "Compressed total-domain u32 equality",
+      "class": "arithmetic/word",
+      "summary": "Canonical two-item ScriptNum wire adapter for u32 equality.",
+      "status": "experimental",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-10",
+      "knowledge_page": "knowledge/primitives/u32-compressed-equal.md",
+      "implementation": "src/arithmetic/u32/stack.rs",
+      "documentation": "src/arithmetic/u32/README.md",
+      "tests": [
+        "arithmetic::u32::stack::tests::test_u32_compressed_equal_boundaries",
+        "arithmetic::u32::stack::tests::test_u32_compressed_equal_rejects_noncanonical_inputs",
+        "primitive_metrics::u32_compressed_equal_metrics_are_current",
+        "examples/u32_compressed_equal_benchmark.rs"
+      ],
+      "references": [
+        "bip-342",
+        "bitcoin-script-locked",
+        "bitcoin-scriptexec-locked"
+      ],
+      "techniques": [
+        "compact-wire",
+        "canonical-encoding"
+      ],
+      "security": "No independent cryptographic claim. Both compressed words are hostile and must pass exact canonical-wire checks before direct comparison; complete protocol binding and deployment validation remain open.",
+      "stack_contract": "... word_b word_a -> ... (word_a == word_b); both inputs are consumed and unrelated lower stack state is preserved.",
+      "configurations": [
+        {
+          "id": "representative-01020304",
+          "label": "Compressed equality versus four-byte baseline",
+          "parameters": {
+            "value": "0x01020304",
+            "hint_items_per_invocation": 0,
+            "complete_input_items": 2
+          },
+          "includes": "fragment-with-memory: two canonical-wire checks and direct equality; excludes input pushes, terminal predicate, transaction framing, and unrelated live state",
+          "script_bytes": 37,
+          "witness_bytes": 11,
+          "witness_bytes_max": 13,
+          "max_stack_items": 5,
+          "executed_opcodes": null,
+          "validation_weight": 0,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 37,
+          "metric_keys": [
+            "u32_compressed_equal",
+            "u32_compressed_equal_witness",
+            "u32_compressed_equal_witness_max",
+            "u32_compressed_equal_stack"
+          ]
+        },
+        {
+          "id": "byte-baseline",
+          "label": "Four-byte u32_equal() baseline",
+          "parameters": {
+            "value": "0x01020304",
+            "complete_input_items": 8
+          },
+          "includes": "fragment-only: four-byte equality operation; excludes operand pushes, terminal predicate, transaction framing, and unrelated live state",
+          "script_bytes": 18,
+          "witness_bytes": 17,
+          "witness_bytes_max": 17,
+          "max_stack_items": 9,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 18,
+          "metric_keys": [
+            "u32_equal_witness",
+            "u32_equal_stack"
+          ]
+        }
+      ],
+      "limitations": [
+        "Dominated by the four-byte baseline for locking-script bytes",
+        "Dynamic opcode count is unavailable from the local executor",
+        "Bitcoin Core, complete-transaction, relay-policy, and canonical witness-policy validation remain open"
+      ],
+      "open_problems": [
+        "OP-002",
+        "OP-003"
+      ]
+    },
     {
       "id": "arithmetic/scriptnum-constant-mul",
       "name": "ScriptNum constant multiplication",

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -18,6 +18,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Native secp256k1 base-field square | 29 balanced radix-512 digits, symmetry-specialized | 14,541 | 94-byte/67-item incremental hint; certified operand; 614-item strict peak |
 | Three native secp256k1 ordinary multiplies | Shared table, destructive third-gate recombination | 59,163 | 280-byte/201-item incremental hint; 993-item strict peak; unoptimized above cutoff |
 | Bounded RNS add | Legacy RNS add | 216 | Modulo 69,300 |
+| Compressed u32 equality | Canonical two-item ScriptNum wire comparison | 37 | 2 witness items; 11 representative bytes; 5-item peak |
 | Bounded RNS multiply | Legacy RNS multiply | 1,561 | 903-item peak |
 | Exact 256-bit-product RNS add | 75-prime canonical coordinatewise | 1,131 | 513-bit composite range; 151-item peak |
 | Exact 256-by-256-bit RNS multiply baseline | 75-prime table/Horner hybrid | 15,624 | No relation carries; 183-item peak |

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -6,7 +6,7 @@ reproducible constructions. The local Rust library is one source of evidence;
 it is not the boundary of the atlas.
 
 The catalog is explicitly time-scoped. Its current review date is
-**2026-09-04**. A record's `as_of` field says when its claims were last checked.
+**2026-09-10**. A record's `as_of` field says when its claims were last checked.
 Missing records are unknown coverage, not proof of nonexistence.
 
 ## How to answer a research question

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,14 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+
+## NR-044: Compressed u32 equality trades locking bytes for witness shape
+
+`u32_compressed_equal()` compares two canonical compressed u32 ScriptNums
+directly. Against the existing four-byte `u32_equal()` fragment it costs 37
+instead of 18 locking bytes, but reduces the representative witness from
+eight data items and 17 serialized bytes to two items and 11 bytes. The
+maximum `0x80000000` sentinel witness is 13 bytes. This is useful when live
+stack items or witness width dominate, but it is dominated for locking-script
+bytes and is not a general byte win. Evidence is `locally-reproduced`;
+deployment is `unclassified`.

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -10,6 +10,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [Hinted ScriptNum division](scriptnum-hinted-div.md)
 - [u4 digit arithmetic](u4.md)
 - [u32 word arithmetic](u32.md)
+- [Compressed total-domain u32 equality](u32-compressed-equal.md)
 - [u31 prime-field arithmetic](u31.md)
 - [Native secp256k1 base-field arithmetic](secp256k1-field.md)
 - [Ed25519 base-field multiplication](ed25519-field.md)

--- a/knowledge/primitives/u32-compressed-equal.md
+++ b/knowledge/primitives/u32-compressed-equal.md
@@ -1,0 +1,52 @@
+# Compressed total-domain u32 equality
+
+## Research question
+
+Can equality over the repository's four-byte u32 representation be exposed
+over two canonical compressed ScriptNum words without expanding either word?
+
+## Construction and threat model
+
+`u32_compressed_equal()` consumes the top two compressed u32 ScriptNums,
+checks their exact canonical encodings, and compares the wire values directly.
+The `0x80000000` value is the one accepted five-byte sentinel; all other
+values must round-trip through the ScriptNum zero-add canonicalization check.
+The two inputs are hostile. Non-minimal encodings, negative zero, and an
+invalid five-byte value are rejected before comparison. The result is one
+Boolean and unrelated lower stack state is preserved.
+
+## Comparison objective and boundary
+
+The objective is witness item count and serialization, compared with
+`u32_equal()` under the same two-word equality and terminal-check boundary.
+The fragment-with-memory boundary includes canonical-wire checks and the
+equality operation; it excludes input pushes, terminal predicates, and
+transaction framing.
+
+| Construction | Script bytes | Representative witness | Maximum witness | Data items | Peak items | Static non-push opcodes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Compressed ScriptNum equality | 37 | 11 | 13 | 2 | 5 | 21 |
+| Four-byte `u32_equal()` baseline | 18 | 17 | 17 | 8 | 9 | 16 |
+
+The compressed form saves six witness items and six representative witness
+bytes, but costs 19 locking bytes. It is therefore useful when witness shape
+or live item count matters, not as a universal script-byte optimization.
+
+## Evidence and execution class
+
+Evidence is `locally-reproduced`; deployment is `unclassified`. Deterministic
+tests cover zero, positive values, the signed boundary, the `0x80000000`
+sentinel, all-ones, equal and unequal pairs, plus malformed encodings. The
+strict fixture uses the locked `bitcoin-scriptexec` revision in tapscript mode
+with the combined 1,000-item stack limit enabled. Dynamic opcode counts are
+not available from the local executor. No Bitcoin Core, complete-transaction,
+relay-policy, or cryptographic claim is made.
+
+## Reproduction
+
+```sh
+cargo test --locked u32_compressed_equal --lib
+cargo test --locked --test primitive_metrics u32_compressed_equal_metrics_are_current
+cargo run --locked --release --example u32_compressed_equal_benchmark
+python3 tools/kb.py validate
+```

--- a/research/u32-compressed-equal/README.md
+++ b/research/u32-compressed-equal/README.md
@@ -1,0 +1,19 @@
+# Compressed total-domain u32 equality
+
+This research fixture measures `u32_compressed_equal()` against the existing
+four-byte `u32_equal()` operation. It validates the exact compressed ScriptNum
+wire boundary before comparing two hostile inputs.
+
+The representative fixture uses `0x01020304`; the maximum witness fixture uses
+the `0x80000000` sentinel. Reproduce it with:
+
+```sh
+cargo test --locked u32_compressed_equal --lib
+cargo test --locked --test primitive_metrics u32_compressed_equal_metrics_are_current
+cargo run --locked --release --example u32_compressed_equal_benchmark
+```
+
+The local result is `locally-reproduced` under `research-unlimited` execution
+classification for this fragment. The strict executor enforces the combined
+1,000-item stack limit, but this work does not claim Bitcoin Core or relay
+policy validation.

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -37,6 +37,7 @@ as less-than-or-equal.
 | `u32_lessthanorequal()` | <!-- metric:u32_lessthanorequal -->61<!-- /metric:u32_lessthanorequal --> bytes | 0 bytes | <!-- metric:u32_lessthanorequal_stack -->13<!-- /metric:u32_lessthanorequal_stack --> items |
 | `u32_or(0, 1, 3)` (table excluded) | <!-- metric:u32_or -->326<!-- /metric:u32_or --> bytes | 0 bytes | <!-- metric:u32_or_stack -->272<!-- /metric:u32_or_stack --> items, including table |
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
+| `u32_compressed_equal()` | <!-- metric:u32_compressed_equal -->37<!-- /metric:u32_compressed_equal --> bytes | <!-- metric:u32_compressed_equal_witness -->11<!-- /metric:u32_compressed_equal_witness --> bytes | <!-- metric:u32_compressed_equal_stack -->5<!-- /metric:u32_compressed_equal_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
 
@@ -68,3 +69,13 @@ caller.
 No hints are required. A witness-supplied word occupies four stack items, most
 significant byte first in the module's normal representation. Binary operation
 inputs and any shared logic table must already be at the documented depths.
+
+`u32_compressed_equal()` accepts two canonical compressed u32 ScriptNums and
+returns one Boolean. It checks the exact ScriptNum encoding, including the
+`0x80000000` sentinel, then compares the canonical wire values directly; it
+does not expand the words. The representative compressed witness is two data
+items and 11 serialized bytes, versus eight items and 17 bytes for the
+four-byte `u32_equal()` witness. The maximum sentinel witness is 13 bytes.
+The 37-byte fragment is a deliberate trade: it reduces witness item count and
+width while costing 19 more locking bytes than `u32_equal()`. The measured
+snapshot records a <!-- metric:u32_compressed_equal_witness_max -->13<!-- /metric:u32_compressed_equal_witness_max -->-byte maximum witness and a <!-- metric:u32_equal_witness -->17<!-- /metric:u32_equal_witness -->-byte, <!-- metric:u32_equal_stack -->9<!-- /metric:u32_equal_stack -->-item byte baseline.

--- a/src/arithmetic/u32/stack.rs
+++ b/src/arithmetic/u32/stack.rs
@@ -55,6 +55,35 @@ pub fn u32_notequal() -> Script {
     }
 }
 
+fn certify_compressed_word() -> Script {
+    script! {
+        OP_DUP
+        OP_SIZE
+        5
+        OP_EQUAL
+        OP_IF
+            -2147483648
+            OP_EQUALVERIFY
+        OP_ELSE
+            OP_DUP
+            0
+            OP_ADD
+            OP_EQUALVERIFY
+        OP_ENDIF
+    }
+}
+
+/// Compares two canonical compressed u32 ScriptNums for equality.
+pub fn u32_compressed_equal() -> Script {
+    script! {
+        { certify_compressed_word() }
+        OP_TOALTSTACK
+        { certify_compressed_word() }
+        OP_FROMALTSTACK
+        OP_EQUAL
+    }
+}
+
 pub fn u32_toaltstack() -> Script {
     script! {
         OP_TOALTSTACK
@@ -157,7 +186,13 @@ pub fn u32_uncompress() -> Script {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::support::execution::run;
+    use crate::support::execution::{execute_script_with_inputs_strict, run};
+
+    fn scriptnum(value: u32) -> Vec<u8> {
+        let mut bytes = [0u8; 8];
+        let length = bitcoin::script::write_scriptint(&mut bytes, i64::from(value as i32));
+        bytes[..length].to_vec()
+    }
 
     #[test]
     fn test_u32_notequal() {
@@ -176,6 +211,47 @@ mod tests {
                 OP_EQUAL
             };
             run(script);
+        }
+    }
+
+    #[test]
+    fn test_u32_compressed_equal_boundaries() {
+        for &(a, b) in &[
+            (0, 0),
+            (0, 1),
+            (0x7fff_ffff, 0x7fff_ffff),
+            (0x8000_0000, 0x8000_0000),
+            (u32::MAX, u32::MAX),
+            (u32::MAX, 0),
+        ] {
+            let result = execute_script_with_inputs_strict(
+                script! {
+                    { u32_compressed_equal() }
+                    { (a == b) as u32 }
+                    OP_EQUAL
+                },
+                vec![scriptnum(b), scriptnum(a)],
+            );
+            assert!(
+                result.success,
+                "compressed equality failed for {a:08x} == {b:08x}: {result}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_u32_compressed_equal_rejects_noncanonical_inputs() {
+        for inputs in [
+            vec![vec![1, 0], scriptnum(1)],
+            vec![vec![0, 0, 0, 0x80], scriptnum(0)],
+            vec![vec![1, 0, 0, 0, 0], scriptnum(0)],
+        ] {
+            let result =
+                execute_script_with_inputs_strict(script! { { u32_compressed_equal() } }, inputs);
+            assert!(
+                result.error.is_some(),
+                "accepted malformed compressed input: {result}"
+            );
         }
     }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -93,6 +93,67 @@ fn max_stack_items_strict(script: bitcoin_script::Script, witness: Vec<Vec<u8>>)
     result.stats.max_nb_stack_items
 }
 
+fn compressed_u32_witness(value: u32) -> Vec<u8> {
+    scriptnum(i64::from(value as i32))
+}
+
+fn byte_u32_witness(value: u32) -> [Vec<u8>; 4] {
+    [
+        scriptnum(i64::from(value >> 24)),
+        scriptnum(i64::from((value >> 16) & 0xff)),
+        scriptnum(i64::from((value >> 8) & 0xff)),
+        scriptnum(i64::from(value & 0xff)),
+    ]
+}
+
+fn u32_compressed_equal_metrics() -> Vec<Metric> {
+    const VALUE: u32 = 0x0102_0304;
+    let compressed = u32::stack::u32_compressed_equal();
+    let byte_baseline = u32::stack::u32_equal();
+    let compressed_witness = vec![compressed_u32_witness(VALUE), compressed_u32_witness(VALUE)];
+    let byte_witness = byte_u32_witness(VALUE)
+        .into_iter()
+        .chain(byte_u32_witness(VALUE))
+        .collect::<Vec<_>>();
+    let compressed_stack = max_stack_items_strict(compressed.clone(), compressed_witness.clone());
+    let byte_stack = max_stack_items_strict(byte_baseline.clone(), byte_witness.clone());
+    vec![
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_equal",
+            value: script_len(compressed.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_equal_witness",
+            value: witness_size(&compressed_witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_equal_witness_max",
+            value: witness_size(&[
+                compressed_u32_witness(0x8000_0000),
+                compressed_u32_witness(0x8000_0000),
+            ]),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_equal_stack",
+            value: compressed_stack,
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_equal_witness",
+            value: witness_size(&byte_witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_equal_stack",
+            value: byte_stack,
+        },
+    ]
+}
+
 fn prince_metrics() -> Vec<Metric> {
     let fragment = prince::prince_encrypt(0);
     let compiled = fragment.clone().compile_with_policy();
@@ -3987,6 +4048,7 @@ fn metrics() -> Vec<Metric> {
         },
     ]
     .into_iter()
+    .chain(u32_compressed_equal_metrics())
     .chain(prince_metrics())
     .chain(winternitz_metrics())
     .chain(winternitz_sha256_metrics())
@@ -4035,6 +4097,11 @@ fn winternitz20_metrics_are_current() {
 #[test]
 fn prince_metrics_are_current() {
     check_readme_metrics(prince_metrics());
+}
+
+#[test]
+fn u32_compressed_equal_metrics_are_current() {
+    check_readme_metrics(u32_compressed_equal_metrics());
 }
 
 /// This isolated fixture exercises only the two small packed decoders. It


### PR DESCRIPTION
## Summary

- add `u32_compressed_equal()` for canonical compressed u32 ScriptNums
- reject non-minimal encodings, negative zero, and invalid five-byte inputs
- add deterministic focused tests, benchmark, metric markers, catalog entry, and comparison/negative-result documentation

## Measurements

The compressed fragment is 37 locking bytes with a representative 11-byte, 2-item witness and a 5-item peak. The four-byte `u32_equal()` baseline is 18 locking bytes with a representative 17-byte, 8-item witness and a 9-item peak. This is a witness-shape tradeoff, not a general locking-byte win.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked u32_compressed_equal --lib`
- `cargo test --locked --test primitive_metrics u32_compressed_equal_metrics_are_current`
- `cargo run --locked --release --example u32_compressed_equal_benchmark`
- `python3 tools/kb.py validate`
- `git diff --check`

The full repository test suite was intentionally not run.