### PR TITLE
feat(arithmetic): add compressed u32 unsigned ordering

### DIFF
--- a/examples/u32_compressed_lessthan_benchmark.rs
+++ b/examples/u32_compressed_lessthan_benchmark.rs
@@ -1,0 +1,94 @@
+use bitcoin::consensus::encode::serialize;
+use bitcoin::{script::Instruction, Witness};
+use bitcoin_lab::{
+    arithmetic::u32::cmp::{u32_compressed_lessthan, u32_lessthan},
+    support::{execution::execute_script_with_inputs_strict, script::ScriptCompilation},
+};
+use bitcoin_script::script;
+
+fn scriptnum(value: u32) -> Vec<u8> {
+    let mut bytes = [0u8; 8];
+    let length = bitcoin::script::write_scriptint(&mut bytes, i64::from(value as i32));
+    bytes[..length].to_vec()
+}
+
+fn byte_word(value: u32) -> [Vec<u8>; 4] {
+    [
+        scriptnum(value >> 24),
+        scriptnum((value >> 16) & 0xff),
+        scriptnum((value >> 8) & 0xff),
+        scriptnum(value & 0xff),
+    ]
+}
+
+fn static_non_push(script: &bitcoin_script::Script) -> usize {
+    script
+        .clone()
+        .compile_with_policy()
+        .instructions()
+        .map(|instruction| instruction.expect("generated fragment must parse"))
+        .filter(
+            |instruction| matches!(instruction, Instruction::Op(opcode) if opcode.to_u8() > 0x60),
+        )
+        .count()
+}
+
+fn main() {
+    let a = 0x0102_0304;
+    let b = 0x0506_0708;
+    let compressed = u32_compressed_lessthan();
+    let byte_baseline = u32_lessthan();
+    let compressed_witness = vec![scriptnum(a), scriptnum(b)];
+    let byte_witness = byte_word(a)
+        .into_iter()
+        .chain(byte_word(b))
+        .collect::<Vec<_>>();
+    let compressed_leaf = script! {
+        { compressed.clone() }
+        OP_VERIFY
+        OP_TRUE
+    };
+    let byte_leaf = script! {
+        { byte_baseline.clone() }
+        OP_VERIFY
+        OP_TRUE
+    };
+    let compressed_result =
+        execute_script_with_inputs_strict(compressed_leaf, compressed_witness.clone());
+    let byte_result = execute_script_with_inputs_strict(byte_leaf, byte_witness.clone());
+    assert!(
+        compressed_result.success,
+        "compressed less-than failed: {compressed_result}"
+    );
+    assert!(byte_result.success, "byte less-than failed: {byte_result}");
+
+    for (name, fragment, witness, result) in [
+        (
+            "compressed",
+            compressed,
+            compressed_witness,
+            compressed_result,
+        ),
+        ("byte_baseline", byte_baseline, byte_witness, byte_result),
+    ] {
+        let compiled = fragment.clone().compile_with_policy();
+        println!("{name}_script_bytes={}", compiled.len());
+        println!(
+            "{name}_witness_bytes={}",
+            serialize(&Witness::from_slice(&witness)).len()
+        );
+        println!("{name}_witness_data_items={}", witness.len());
+        println!("{name}_hint_items=0");
+        println!("{name}_stack_peak={}", result.stats.max_nb_stack_items);
+        println!("{name}_executed_opcodes={}", result.stats.opcode_count);
+        println!(
+            "{name}_static_non_push_opcodes={}",
+            static_non_push(&fragment)
+        );
+        println!(
+            "{name}_validation_weight_delta={}",
+            result.stats.start_validation_weight - result.stats.validation_weight
+        );
+    }
+    println!("context=tapscript stack_limit=1000");
+}

--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1,8 +1,97 @@
 {
   "schema_version": 1,
-  "as_of": "2026-09-01",
+  "as_of": "2026-09-11",
   "cost_model": "knowledge/cost-model.md",
   "records": [
+    {
+      "id": "arithmetic/u32-compressed-lessthan",
+      "name": "Compressed total-domain u32 unsigned less-than",
+      "class": "arithmetic/word",
+      "summary": "Canonical two-item ScriptNum wire adapter for total unsigned u32 ordering.",
+      "status": "experimental",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/u32-compressed-lessthan.md",
+      "implementation": "src/arithmetic/u32/cmp.rs",
+      "documentation": "src/arithmetic/u32/README.md",
+      "tests": [
+        "arithmetic::u32::cmp::tests::test_u32_compressed_lessthan_boundaries_and_random_values",
+        "arithmetic::u32::cmp::tests::test_u32_compressed_lessthan_rejects_noncanonical_inputs",
+        "primitive_metrics::u32_compressed_lessthan_metrics_are_current",
+        "examples/u32_compressed_lessthan_benchmark.rs"
+      ],
+      "references": [
+        "bip-342",
+        "bitcoin-script-locked",
+        "bitcoin-scriptexec-locked"
+      ],
+      "techniques": [
+        "compact-wire",
+        "canonical-encoding",
+        "sign-magnitude-normalization"
+      ],
+      "security": "No independent cryptographic claim. Both compressed words are hostile and must pass exact canonical-wire checks before sign correction and comparison; complete protocol binding and deployment validation remain open.",
+      "stack_contract": "... word_a word_b -> ... (word_a < word_b); both inputs are consumed and unrelated lower stack state is preserved.",
+      "configurations": [
+        {
+          "id": "representative-01020304-less-than-05060708",
+          "label": "Compressed unsigned less-than versus four-byte baseline",
+          "parameters": {
+            "a": "0x01020304",
+            "b": "0x05060708",
+            "hint_items_per_invocation": 0,
+            "complete_input_items": 2
+          },
+          "includes": "fragment-with-memory: two canonical-wire checks, sign/magnitude normalization, unsigned comparison, and cross-sign correction; excludes input pushes, terminal predicate, transaction framing, and unrelated live state",
+          "script_bytes": 124,
+          "witness_bytes": 11,
+          "witness_bytes_max": 8,
+          "max_stack_items": 6,
+          "executed_opcodes": null,
+          "validation_weight": 0,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 124,
+          "metric_keys": [
+            "u32_compressed_lessthan",
+            "u32_compressed_lessthan_witness",
+            "u32_compressed_lessthan_witness_max",
+            "u32_compressed_lessthan_stack"
+          ]
+        },
+        {
+          "id": "byte-baseline",
+          "label": "Four-byte u32_lessthan() baseline",
+          "parameters": {
+            "a": "0x01020304",
+            "b": "0x05060708",
+            "complete_input_items": 8
+          },
+          "includes": "fragment-only: four-byte unsigned comparison; excludes operand pushes, terminal predicate, transaction framing, and unrelated live state",
+          "script_bytes": 38,
+          "witness_bytes": 17,
+          "witness_bytes_max": 17,
+          "max_stack_items": 9,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 38,
+          "metric_keys": [
+            "u32_lessthan_witness",
+            "u32_lessthan_stack"
+          ]
+        }
+      ],
+      "limitations": [
+        "Dominated by the four-byte baseline for locking-script bytes",
+        "Dynamic opcode count is unavailable from the local executor",
+        "Bitcoin Core, complete-transaction, relay-policy, and canonical witness-policy validation remain open"
+      ],
+      "open_problems": [
+        "OP-002",
+        "OP-003"
+      ]
+    },
     {
       "id": "arithmetic/scriptnum-constant-mul",
       "name": "ScriptNum constant multiplication",

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -18,6 +18,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Native secp256k1 base-field square | 29 balanced radix-512 digits, symmetry-specialized | 14,541 | 94-byte/67-item incremental hint; certified operand; 614-item strict peak |
 | Three native secp256k1 ordinary multiplies | Shared table, destructive third-gate recombination | 59,163 | 280-byte/201-item incremental hint; 993-item strict peak; unoptimized above cutoff |
 | Bounded RNS add | Legacy RNS add | 216 | Modulo 69,300 |
+| Compressed u32 unsigned less-than | Canonical two-item ScriptNum ordering | 124 | 2 witness items; 11 representative bytes; 6-item peak |
 | Bounded RNS multiply | Legacy RNS multiply | 1,561 | 903-item peak |
 | Exact 256-bit-product RNS add | 75-prime canonical coordinatewise | 1,131 | 513-bit composite range; 151-item peak |
 | Exact 256-by-256-bit RNS multiply baseline | 75-prime table/Horner hybrid | 15,624 | No relation carries; 183-item peak |

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -6,7 +6,7 @@ reproducible constructions. The local Rust library is one source of evidence;
 it is not the boundary of the atlas.
 
 The catalog is explicitly time-scoped. Its current review date is
-**2026-09-04**. A record's `as_of` field says when its claims were last checked.
+**2026-09-11**. A record's `as_of` field says when its claims were last checked.
 Missing records are unknown coverage, not proof of nonexistence.
 
 ## How to answer a research question

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,15 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+
+## NR-045: Compressed u32 ordering trades locking bytes for witness shape
+
+`u32_compressed_lessthan()` performs total unsigned ordering directly over two
+canonical compressed u32 ScriptNums. Against the existing byte-oriented
+`u32_lessthan()` fragment it costs 124 instead of 38 locking bytes, but reduces
+the representative witness from eight data items and 17 serialized bytes to
+two items and 11 bytes. The sentinel-boundary witness is 8 bytes and the
+measured peak is 6 rather than 9 items. This is useful when witness shape or
+live stack items dominate, but it is dominated for locking-script bytes and
+is not a general byte win. Evidence is `locally-reproduced`; deployment is
+`unclassified`.

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -10,6 +10,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [Hinted ScriptNum division](scriptnum-hinted-div.md)
 - [u4 digit arithmetic](u4.md)
 - [u32 word arithmetic](u32.md)
+- [Compressed total-domain u32 unsigned less-than](u32-compressed-lessthan.md)
 - [u31 prime-field arithmetic](u31.md)
 - [Native secp256k1 base-field arithmetic](secp256k1-field.md)
 - [Ed25519 base-field multiplication](ed25519-field.md)

--- a/knowledge/primitives/u32-compressed-lessthan.md
+++ b/knowledge/primitives/u32-compressed-lessthan.md
@@ -1,0 +1,60 @@
+# Compressed total-domain u32 unsigned less-than
+
+## Research question
+
+Can unsigned less-than over the repository's four-byte u32 representation be
+performed directly on two canonical compressed ScriptNum words without
+expanding either word into four byte limbs?
+
+## Hypothesis and construction
+
+The compressed wire value is a signed ScriptNum: values below `2^31` are
+nonnegative and values at or above `2^31` are negative. Within either sign
+half, signed ordering is already unsigned ordering; only cross-sign pairs
+need correction. `u32_compressed_lessthan()` therefore validates both raw
+encodings, maps each word to `(sign, low31)` while treating the five-byte
+`0x80000000` sentinel as `(1, 0)`, compares the legal 31-bit values, and
+applies the sign correction.
+
+The witness is hostile. Non-minimal encodings, negative zero, and invalid
+five-byte values are rejected before normalization. The operation follows the
+existing comparator contract `... a b -> ... (a < b)`, consumes both words,
+and preserves unrelated lower stack state.
+
+## Comparison objective and boundary
+
+The objective is witness width and live stack-item count compared with
+`u32_lessthan()` under the same two-word operation and terminal-check boundary.
+The fragment-with-memory boundary includes both canonical-wire checks,
+sign/magnitude normalization, comparison, and sign correction. It excludes
+input pushes, terminal predicates, and transaction framing.
+
+| Construction | Script bytes | Representative witness | Sentinel-boundary witness | Data items | Peak items | Static non-push opcodes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Compressed ScriptNum unsigned less-than | 124 | 11 bytes | 8 bytes | 2 | 6 | 72 |
+| Four-byte `u32_lessthan()` baseline | 38 | 17 bytes | not measured | 8 | 9 | 32 |
+
+The compressed form saves six representative witness bytes and six entry
+items, and reduces the measured peak by three items, but costs 86 locking
+bytes. It is a witness-shape primitive, not a general locking-byte
+optimization.
+
+## Evidence and execution class
+
+Evidence is `locally-reproduced`; deployment is `unclassified`. Deterministic
+tests cover all pairings of eight semantic boundary values, 256 pairs from a
+fixed ChaCha20 seed, the signed boundary, the five-byte sentinel, equal
+values, and malformed encodings. The benchmark uses the locked
+`bitcoin-scriptexec` revision in tapscript mode with the combined 1,000-item
+stack limit enabled. Dynamic opcode counts are unavailable from the local
+executor. No Bitcoin Core, complete-transaction, relay-policy, or
+cryptographic claim is made.
+
+## Reproduction
+
+```sh
+cargo test --locked u32_compressed_lessthan --lib
+cargo test --locked --test primitive_metrics u32_compressed_lessthan_metrics_are_current
+cargo run --locked --release --example u32_compressed_lessthan_benchmark
+python3 tools/kb.py validate
+```

--- a/research/u32-compressed-lessthan/README.md
+++ b/research/u32-compressed-lessthan/README.md
@@ -1,0 +1,19 @@
+# Compressed total-domain u32 unsigned less-than
+
+This fixture measures `u32_compressed_lessthan()` against the existing
+four-byte `u32_lessthan()` operation. It validates exact compressed ScriptNum
+wire encodings, maps signed compressed words to a sign bit and legal low-31
+value, and corrects ordering across the sign boundary.
+
+The representative fixture compares `0x01020304 < 0x05060708`; the boundary
+fixture includes `0 < 0x80000000`. Reproduce it with:
+
+```sh
+cargo test --locked u32_compressed_lessthan --lib
+cargo test --locked --test primitive_metrics u32_compressed_lessthan_metrics_are_current
+cargo run --locked --release --example u32_compressed_lessthan_benchmark
+```
+
+The result is `locally-reproduced` under an `unclassified` deployment class.
+Strict execution enforces the combined 1,000-item stack limit, but this work
+does not claim Bitcoin Core or relay-policy validation.

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -34,6 +34,7 @@ as less-than-or-equal.
 | `u32_add_drop(0, 1)` | <!-- metric:u32_add_drop -->78<!-- /metric:u32_add_drop --> bytes | 0 bytes | <!-- metric:u32_add_drop_stack -->10<!-- /metric:u32_add_drop_stack --> items |
 | `u32_sub_drop(0, 1)` | <!-- metric:u32_sub_drop -->77<!-- /metric:u32_sub_drop --> bytes | 0 bytes | <!-- metric:u32_sub_drop_stack -->9<!-- /metric:u32_sub_drop_stack --> items |
 | `u32_lessthan()` | <!-- metric:u32_lessthan -->38<!-- /metric:u32_lessthan --> bytes | 0 bytes | <!-- metric:u32_lessthan_stack -->9<!-- /metric:u32_lessthan_stack --> items |
+| `u32_compressed_lessthan()` | <!-- metric:u32_compressed_lessthan -->124<!-- /metric:u32_compressed_lessthan --> bytes | <!-- metric:u32_compressed_lessthan_witness -->11<!-- /metric:u32_compressed_lessthan_witness --> bytes | <!-- metric:u32_compressed_lessthan_stack -->6<!-- /metric:u32_compressed_lessthan_stack --> items |
 | `u32_lessthanorequal()` | <!-- metric:u32_lessthanorequal -->61<!-- /metric:u32_lessthanorequal --> bytes | 0 bytes | <!-- metric:u32_lessthanorequal_stack -->13<!-- /metric:u32_lessthanorequal_stack --> items |
 | `u32_or(0, 1, 3)` (table excluded) | <!-- metric:u32_or -->326<!-- /metric:u32_or --> bytes | 0 bytes | <!-- metric:u32_or_stack -->272<!-- /metric:u32_or_stack --> items, including table |
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
@@ -68,3 +69,9 @@ caller.
 No hints are required. A witness-supplied word occupies four stack items, most
 significant byte first in the module's normal representation. Binary operation
 inputs and any shared logic table must already be at the documented depths.
+
+`u32_compressed_lessthan()` accepts two canonical compressed u32 ScriptNums
+with the same `... a b -> ... (a < b)` contract as `u32_lessthan()`. It
+validates hostile encodings, maps the signed compressed domain to a sign bit
+and a legal 31-bit magnitude, and compares those values without expanding
+four byte limbs. The representative witness is two items and <!-- metric:u32_compressed_lessthan_witness -->11<!-- /metric:u32_compressed_lessthan_witness --> serialized bytes versus <!-- metric:u32_lessthan_witness -->17<!-- /metric:u32_lessthan_witness --> bytes for the byte baseline. The sentinel-boundary maximum is <!-- metric:u32_compressed_lessthan_witness_max -->8<!-- /metric:u32_compressed_lessthan_witness_max --> bytes. The fragment costs 124 locking bytes and peaks at <!-- metric:u32_compressed_lessthan_stack -->6<!-- /metric:u32_compressed_lessthan_stack --> items, so it is a witness-shape tradeoff rather than a general byte win.

--- a/src/arithmetic/u32/cmp.rs
+++ b/src/arithmetic/u32/cmp.rs
@@ -96,12 +96,94 @@ pub fn u32_greaterthanorequal() -> Script {
     u32_cmp_or_equal(script! { OP_GREATERTHAN })
 }
 
+fn certify_compressed_word() -> Script {
+    script! {
+        OP_SIZE
+        5
+        OP_NUMEQUAL
+        OP_IF
+            OP_DUP
+            -2147483648
+            OP_EQUALVERIFY
+        OP_ELSE
+            OP_DUP
+            OP_DUP
+            0
+            OP_ADD
+            OP_EQUALVERIFY
+        OP_ENDIF
+        OP_DROP
+    }
+}
+
+fn normalize_compressed_word() -> Script {
+    script! {
+        OP_SIZE 5 OP_NUMEQUAL
+        OP_IF
+            { -2_147_483_648i64 } OP_EQUALVERIFY
+            1 0
+        OP_ELSE
+            OP_DUP
+            0
+            OP_LESSTHAN
+            OP_IF
+                { 0x7fff_ffffu32 } OP_ADD OP_1ADD
+                1 OP_SWAP
+            OP_ELSE
+                0 OP_SWAP
+            OP_ENDIF
+        OP_ENDIF
+    }
+}
+
+/// Unsigned less-than comparison of two canonical compressed u32 ScriptNums.
+pub fn u32_compressed_lessthan() -> Script {
+    script! {
+        OP_DUP
+        { certify_compressed_word() }
+        OP_TOALTSTACK
+        OP_DUP
+        { certify_compressed_word() }
+        OP_FROMALTSTACK
+        OP_SWAP
+        { normalize_compressed_word() }
+        OP_SWAP
+        OP_TOALTSTACK
+        OP_SWAP
+        OP_TOALTSTACK
+        OP_FROMALTSTACK
+        { normalize_compressed_word() }
+        OP_SWAP
+        OP_TOALTSTACK
+        OP_LESSTHAN
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+
+        // The normalized values are ordered within each sign half. Across
+        // halves, nonnegative values are always below negative values.
+        OP_IF
+            OP_IF
+            OP_ELSE
+                OP_DROP
+                OP_0
+            OP_ENDIF
+        OP_ELSE
+            OP_IF
+                OP_DROP
+                OP_1
+            OP_ENDIF
+        OP_ENDIF
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::arithmetic::u32::stack::u32_push;
-    use crate::support::execution::run;
+    use crate::support::execution::{execute_script_with_inputs_strict, run};
     use rand::Rng;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
 
     #[test]
     fn test_u32_comparisons() {
@@ -125,6 +207,69 @@ mod tests {
         let mut rng = rand::thread_rng();
         for _ in 0..256 {
             check_comparisons(rng.gen(), rng.gen());
+        }
+    }
+
+    fn scriptnum(value: u32) -> Vec<u8> {
+        let mut bytes = [0u8; 8];
+        let length = bitcoin::script::write_scriptint(&mut bytes, i64::from(value as i32));
+        bytes[..length].to_vec()
+    }
+
+    fn check_compressed_lessthan(a: u32, b: u32) {
+        let result = execute_script_with_inputs_strict(
+            script! {
+                { u32_compressed_lessthan() }
+                { (a < b) as u32 }
+                OP_EQUAL
+            },
+            vec![scriptnum(a), scriptnum(b)],
+        );
+        assert!(
+            result.success,
+            "compressed less-than failed for {a:08x} < {b:08x}: {result}"
+        );
+    }
+
+    #[test]
+    fn test_u32_compressed_lessthan_boundaries_and_random_values() {
+        let boundaries = [
+            0,
+            1,
+            0xff,
+            0x100,
+            0x7fff_ffff,
+            0x8000_0000,
+            0xffff_fffe,
+            u32::MAX,
+        ];
+        for &a in &boundaries {
+            for &b in &boundaries {
+                check_compressed_lessthan(a, b);
+            }
+        }
+
+        let mut rng = ChaCha20Rng::seed_from_u64(0x4330_4c54);
+        for _ in 0..256 {
+            check_compressed_lessthan(rng.gen(), rng.gen());
+        }
+    }
+
+    #[test]
+    fn test_u32_compressed_lessthan_rejects_noncanonical_inputs() {
+        for inputs in [
+            vec![vec![1, 0], scriptnum(1)],
+            vec![vec![0, 0, 0, 0x80], scriptnum(0)],
+            vec![vec![1, 0, 0, 0, 0], scriptnum(0)],
+        ] {
+            let result = execute_script_with_inputs_strict(
+                script! { { u32_compressed_lessthan() } },
+                inputs,
+            );
+            assert!(
+                result.error.is_some(),
+                "accepted malformed compressed input: {result}"
+            );
         }
     }
 

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -93,6 +93,68 @@ fn max_stack_items_strict(script: bitcoin_script::Script, witness: Vec<Vec<u8>>)
     result.stats.max_nb_stack_items
 }
 
+fn compressed_u32_witness(value: u32) -> Vec<u8> {
+    scriptnum(i64::from(value as i32))
+}
+
+fn byte_u32_witness(value: u32) -> [Vec<u8>; 4] {
+    [
+        scriptnum(i64::from(value >> 24)),
+        scriptnum(i64::from((value >> 16) & 0xff)),
+        scriptnum(i64::from((value >> 8) & 0xff)),
+        scriptnum(i64::from(value & 0xff)),
+    ]
+}
+
+fn u32_compressed_lessthan_metrics() -> Vec<Metric> {
+    const A: u32 = 0x0102_0304;
+    const B: u32 = 0x0506_0708;
+    let compressed = u32::cmp::u32_compressed_lessthan();
+    let byte_baseline = u32::cmp::u32_lessthan();
+    let compressed_witness = vec![compressed_u32_witness(A), compressed_u32_witness(B)];
+    let byte_witness = byte_u32_witness(A)
+        .into_iter()
+        .chain(byte_u32_witness(B))
+        .collect::<Vec<_>>();
+    let compressed_stack = max_stack_items_strict(compressed.clone(), compressed_witness.clone());
+    let byte_stack = max_stack_items_strict(byte_baseline.clone(), byte_witness.clone());
+    vec![
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_lessthan",
+            value: script_len(compressed),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_lessthan_witness",
+            value: witness_size(&compressed_witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_lessthan_witness_max",
+            value: witness_size(&[
+                compressed_u32_witness(0),
+                compressed_u32_witness(0x8000_0000),
+            ]),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_lessthan_stack",
+            value: compressed_stack,
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_lessthan_witness",
+            value: witness_size(&byte_witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_lessthan_stack",
+            value: byte_stack,
+        },
+    ]
+}
+
 fn prince_metrics() -> Vec<Metric> {
     let fragment = prince::prince_encrypt(0);
     let compiled = fragment.clone().compile_with_policy();
@@ -3987,6 +4049,7 @@ fn metrics() -> Vec<Metric> {
         },
     ]
     .into_iter()
+    .chain(u32_compressed_lessthan_metrics())
     .chain(prince_metrics())
     .chain(winternitz_metrics())
     .chain(winternitz_sha256_metrics())
@@ -4035,6 +4098,11 @@ fn winternitz20_metrics_are_current() {
 #[test]
 fn prince_metrics_are_current() {
     check_readme_metrics(prince_metrics());
+}
+
+#[test]
+fn u32_compressed_lessthan_metrics_are_current() {
+    check_readme_metrics(u32_compressed_lessthan_metrics());
 }
 
 /// This isolated fixture exercises only the two small packed decoders. It


### PR DESCRIPTION
## Summary

- add `u32_compressed_lessthan()` for total unsigned comparison of two canonical compressed u32 ScriptNums
- validate the exact compressed wire encoding, normalize signed ScriptNums to sign/magnitude, and correct cross-sign ordering without expanding four byte limbs
- document the cost boundary, metrics, and negative result against the existing byte-oriented comparator

## Measurements

- compressed fragment: 124 locking bytes, 11 representative witness bytes, 2 witness data items, 6-item stack peak
- byte baseline: 38 locking bytes, 17 representative witness bytes, 8 witness data items, 9-item stack peak
- the compressed form is a witness-shape tradeoff, not a general locking-byte win

## Verification

- `python3 tools/kb.py validate`
- `cargo fmt --all -- --check`
- `cargo test --locked u32_compressed_lessthan --lib`
- `cargo test --locked --test primitive_metrics u32_compressed_lessthan_metrics_are_current`
- `cargo run --locked --release --example u32_compressed_lessthan_benchmark`
- `git diff --check`

The full repository test suite was intentionally not run; verification was scoped to the new primitive and its metrics.
