### PR TITLE
feat(arithmetic): add compressed u32 logical right shift

### DIFF
--- a/examples/u32_compressed_rshift_benchmark.rs
+++ b/examples/u32_compressed_rshift_benchmark.rs
@@ -1,0 +1,71 @@
+use bitcoin::consensus::encode::serialize;
+use bitcoin::script::Instruction;
+use bitcoin::Witness;
+use bitcoin_lab::arithmetic::u32::shift::u32_compressed_rshift;
+use bitcoin_lab::arithmetic::u32::stack::{u32_compress, u32_uncompress};
+use bitcoin_lab::support::execution::execute_raw_script_with_inputs_strict;
+use bitcoin_lab::support::script::{Script, ScriptCompilation};
+use bitcoin_script::script;
+
+fn scriptnum(value: u32) -> Vec<u8> {
+    let mut bytes = [0u8; 8];
+    let length = bitcoin::script::write_scriptint(&mut bytes, i64::from(value as i32));
+    bytes[..length].to_vec()
+}
+
+fn byte_shift8() -> Script {
+    script! {
+        OP_TOALTSTACK
+        OP_TOALTSTACK
+        OP_TOALTSTACK
+        OP_TOALTSTACK
+        0
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_DROP
+    }
+}
+
+fn measure(name: &str, script: Script, witness: Vec<Vec<u8>>) {
+    let leaf = script! {
+        { script }
+        OP_VERIFY
+        OP_TRUE
+    }
+    .compile_with_policy();
+    let result = execute_raw_script_with_inputs_strict(leaf.to_bytes(), witness);
+    assert!(result.success, "{name} failed: {result}");
+    let static_non_push_opcodes = leaf
+        .instructions()
+        .map(|instruction| instruction.expect("generated benchmark script must parse"))
+        .filter(|instruction| !matches!(instruction, Instruction::PushBytes(_)))
+        .count();
+    println!("{name}_script_bytes={}", leaf.len());
+    println!(
+        "{name}_witness_bytes={}",
+        serialize(&Witness::from_slice(&[scriptnum(0x89ab_cdef)])).len()
+    );
+    println!("{name}_witness_data_items=1");
+    println!("{name}_hint_items=0");
+    println!("{name}_stack_peak={}", result.stats.max_nb_stack_items);
+    println!("{name}_executed_opcodes=0");
+    println!("{name}_static_non_push_opcodes={static_non_push_opcodes}");
+    println!(
+        "{name}_validation_weight_delta={}",
+        result.stats.validation_weight
+    );
+}
+
+fn main() {
+    const VALUE: u32 = 0x89ab_cdef;
+    let witness = vec![scriptnum(VALUE)];
+    measure("compressed", u32_compressed_rshift(8), witness.clone());
+    measure(
+        "decode_shift_encode_baseline",
+        script! { { u32_uncompress() } { byte_shift8() } { u32_compress() } },
+        witness,
+    );
+    println!("context=tapscript stack_limit=1000");
+}

--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1,8 +1,97 @@
 {
   "schema_version": 1,
-  "as_of": "2026-09-01",
+  "as_of": "2026-09-11",
   "cost_model": "knowledge/cost-model.md",
   "records": [
+    {
+      "id": "arithmetic/u32-compressed-rshift",
+      "name": "Compressed total-domain u32 logical right shift",
+      "class": "arithmetic/word",
+      "summary": "Canonical one-item ScriptNum adapter for logical u32 right shifts.",
+      "status": "experimental",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/u32-compressed-rshift.md",
+      "implementation": "src/arithmetic/u32/shift.rs",
+      "documentation": "src/arithmetic/u32/README.md",
+      "tests": [
+        "arithmetic::u32::shift::tests::test_u32_compressed_rshift_boundaries_and_random_values",
+        "arithmetic::u32::shift::tests::test_u32_compressed_rshift_rejects_noncanonical_inputs",
+        "primitive_metrics::u32_compressed_rshift_metrics_are_current",
+        "examples/u32_compressed_rshift_benchmark.rs"
+      ],
+      "references": [
+        "bip-342",
+        "bitcoin-script-locked",
+        "bitcoin-scriptexec-locked"
+      ],
+      "techniques": [
+        "digit-arithmetic",
+        "metadata-carrier"
+      ],
+      "security": "No independent cryptographic claim. The compressed input is hostile and must pass exact canonical-wire checks before sign/magnitude normalization; complete protocol binding and deployment validation remain open.",
+      "stack_contract": "... word -> ... (word >> shift); shift is 1..=31, the input is consumed, and unrelated lower stack state is preserved.",
+      "configurations": [
+        {
+          "id": "shift-8-direct",
+          "label": "Direct compressed logical right shift by 8",
+          "parameters": {
+            "shift": 8,
+            "value": "0x89abcdef",
+            "hint_items_per_invocation": 0,
+            "complete_input_items": 1
+          },
+          "includes": "fragment-with-memory: canonical-wire check, sign/magnitude normalization, threshold division, and logical high-bit restoration; excludes input push, terminal predicate, transaction framing, and unrelated live state",
+          "script_bytes": 500,
+          "witness_bytes": 6,
+          "witness_bytes_max": 7,
+          "max_stack_items": 5,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 500,
+          "metric_keys": [
+            "u32_compressed_rshift_8",
+            "u32_compressed_rshift_8_witness",
+            "u32_compressed_rshift_8_stack"
+          ]
+        },
+        {
+          "id": "shift-8-decode-baseline",
+          "label": "Decode, byte-shift, and re-encode baseline",
+          "parameters": {
+            "shift": 8,
+            "value": "0x89abcdef",
+            "complete_input_items": 1
+          },
+          "includes": "fragment-only: existing compressed decoder, four-item byte shift, and existing encoder; excludes input push, terminal predicate, transaction framing, and unrelated live state",
+          "script_bytes": 499,
+          "witness_bytes": 6,
+          "witness_bytes_max": 7,
+          "max_stack_items": 7,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 499,
+          "metric_keys": [
+            "u32_compressed_rshift_8_baseline",
+            "u32_compressed_rshift_8_witness",
+            "u32_compressed_rshift_8_baseline_stack"
+          ]
+        }
+      ],
+      "limitations": [
+        "Shift-ladder size varies with the compile-time shift",
+        "Dominated by the local baseline for shift-8 locking-script bytes",
+        "Bitcoin Core, complete-transaction, relay-policy, and canonical witness-policy validation remain open"
+      ],
+      "open_problems": [
+        "OP-002",
+        "OP-003",
+        "OP-014"
+      ]
+    },
     {
       "id": "arithmetic/scriptnum-constant-mul",
       "name": "ScriptNum constant multiplication",

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -18,6 +18,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Native secp256k1 base-field square | 29 balanced radix-512 digits, symmetry-specialized | 14,541 | 94-byte/67-item incremental hint; certified operand; 614-item strict peak |
 | Three native secp256k1 ordinary multiplies | Shared table, destructive third-gate recombination | 59,163 | 280-byte/201-item incremental hint; 993-item strict peak; unoptimized above cutoff |
 | Bounded RNS add | Legacy RNS add | 216 | Modulo 69,300 |
+| Compressed u32 logical right shift | Direct one-item ScriptNum shift by 8 | 500 | 1 witness item; 5-item peak; decode baseline 499 bytes / 7-item peak |
 | Bounded RNS multiply | Legacy RNS multiply | 1,561 | 903-item peak |
 | Exact 256-bit-product RNS add | 75-prime canonical coordinatewise | 1,131 | 513-bit composite range; 151-item peak |
 | Exact 256-by-256-bit RNS multiply baseline | 75-prime table/Horner hybrid | 15,624 | No relation carries; 183-item peak |

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -6,7 +6,7 @@ reproducible constructions. The local Rust library is one source of evidence;
 it is not the boundary of the atlas.
 
 The catalog is explicitly time-scoped. Its current review date is
-**2026-09-04**. A record's `as_of` field says when its claims were last checked.
+**2026-09-11**. A record's `as_of` field says when its claims were last checked.
 Missing records are unknown coverage, not proof of nonexistence.
 
 ## How to answer a research question

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,11 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+
+## NR-043: Direct compressed u32 right shift is a stack-shape tradeoff
+
+`u32_compressed_rshift(8)` avoids four-byte expansion but measures 500 locking
+bytes versus 499 for a local decode-byte-shift-reencode baseline. It does save
+two live stack items, peaking at 5 instead of 7, with the same one-item witness.
+It is therefore not a general byte win. Evidence is `locally-reproduced` and
+deployment is `unclassified`; the result does not close OP-014.

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -293,6 +293,13 @@ setup, script bytes, executed opcodes, and strict stack peaks are compared on
 the same boundary; malformed encodings are rejected; and a complete tapscript
 leaf is differentially validated against a pinned Bitcoin Core revision.
 
+Progress: `u32_compressed_rshift(shift)` now passes deterministic boundary and
+malformed-input tests for every shift in `1..=31`. At shift 8 it costs 500
+fragment bytes and peaks at five items, versus 499 bytes and seven items for a
+local decode-byte-shift-reencode baseline. The full OP-014 criterion remains
+open because the comparison is local and the complete Core differential is
+not yet present.
+
 ## OP-015 — Native secp256k1 field circuit frontier
 
 Turn the native 20,503-byte ordinary multiplication, 20,450-byte factor-16

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -10,6 +10,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [Hinted ScriptNum division](scriptnum-hinted-div.md)
 - [u4 digit arithmetic](u4.md)
 - [u32 word arithmetic](u32.md)
+- [Compressed total-domain u32 logical right shift](u32-compressed-rshift.md)
 - [u31 prime-field arithmetic](u31.md)
 - [Native secp256k1 base-field arithmetic](secp256k1-field.md)
 - [Ed25519 base-field multiplication](ed25519-field.md)

--- a/knowledge/primitives/u32-compressed-rshift.md
+++ b/knowledge/primitives/u32-compressed-rshift.md
@@ -1,0 +1,60 @@
+# Compressed total-domain u32 logical right shift
+
+## Research question
+
+Can a single canonical compressed u32 ScriptNum implement a logical right shift
+without first expanding into four byte limbs?
+
+## Construction
+
+`u32_compressed_rshift(shift)` accepts one compressed ScriptNum representing a
+32-bit unsigned word and supports `shift` in `1..=31`. It first checks the
+canonical wire boundary, maps the sign-carried high bit and the remaining
+value into a legal sign/magnitude pair, divides the 31-bit magnitude by a
+compile-time power of two using threshold subtraction, and restores the
+logical high-bit contribution. The result is a positive canonical ScriptNum
+for every nonzero shift.
+
+The fragment contract is:
+
+```text
+... word -> ... (word >> shift)
+```
+
+Both the compressed input and output are data items; no auxiliary hints are
+required. The fragment does not provide a terminal predicate or clean-stack
+wrapper.
+
+## Measured boundary
+
+All measurements use the repository's policy compilation and strict local
+`bitcoin-scriptexec` tapscript executor with the 1,000-item stack limit. They
+exclude input pushes, the terminal predicate, transaction framing, and
+unrelated live stack state.
+
+| Configuration | Script bytes | Witness bytes | Data items | Peak |
+| --- | ---: | ---: | ---: | ---: |
+| Direct compressed shift by 8 | 500 | 6 representative / 7 sentinel-boundary maximum | 1 | 5 |
+| Decode, byte-shift, re-encode baseline | 499 | 6 representative / 7 sentinel-boundary maximum | 1 | 7 |
+
+The direct form is effectively equal in locking bytes to the local
+decode-shift-reencode baseline at shift 8, while saving two live stack items.
+It is a representation and stack-shape result, not a general byte reduction;
+script size varies with the generated shift ladder.
+
+## Evidence and limitations
+
+Evidence is `locally-reproduced`; deployment is `unclassified`. Boundary and
+deterministic random tests cover every shift from 1 through 31, including
+`0x80000000`, and malformed/trailing encodings are rejected. The baseline is
+an executable local composition of the existing `u32_uncompress`, a byte
+shift-by-8 adapter, and `u32_compress`; it is not an independent Bitcoin Core
+implementation. Complete transaction validation, relay policy, and a pinned
+Core differential remain open under OP-002, OP-003, and OP-014.
+
+Reproduce with:
+
+```sh
+cargo test --locked u32_compressed_rshift --lib
+cargo run --locked --release --example u32_compressed_rshift_benchmark
+```

--- a/research/u32-compressed-rshift/README.md
+++ b/research/u32-compressed-rshift/README.md
@@ -1,0 +1,23 @@
+# Compressed u32 logical right shift
+
+This experiment tests whether the compressed one-item u32 representation can
+perform logical right shifts directly. The implementation validates the
+canonical compressed ScriptNum, separates its sign-carried high bit from a
+legal 31-bit magnitude, uses a generated threshold ladder for division by
+`2^shift`, and restores the high-bit contribution.
+
+The representative measurement is `u32_compressed_rshift(8)` on
+`0x89abcdef`. The direct fragment is 500 locking bytes, uses one six-byte
+serialized witness item, and peaks at five stack items. The local
+decode-byte-shift-reencode baseline is 499 bytes with the same witness and a
+seven-item peak. The sentinel-boundary witness is seven serialized bytes.
+
+Run:
+
+```sh
+cargo test --locked u32_compressed_rshift --lib
+cargo run --locked --release --example u32_compressed_rshift_benchmark
+```
+
+Results are locally reproduced under strict tapscript execution. They are not
+Bitcoin Core or relay-policy validation.

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -35,6 +35,7 @@ as less-than-or-equal.
 | `u32_sub_drop(0, 1)` | <!-- metric:u32_sub_drop -->77<!-- /metric:u32_sub_drop --> bytes | 0 bytes | <!-- metric:u32_sub_drop_stack -->9<!-- /metric:u32_sub_drop_stack --> items |
 | `u32_lessthan()` | <!-- metric:u32_lessthan -->38<!-- /metric:u32_lessthan --> bytes | 0 bytes | <!-- metric:u32_lessthan_stack -->9<!-- /metric:u32_lessthan_stack --> items |
 | `u32_lessthanorequal()` | <!-- metric:u32_lessthanorequal -->61<!-- /metric:u32_lessthanorequal --> bytes | 0 bytes | <!-- metric:u32_lessthanorequal_stack -->13<!-- /metric:u32_lessthanorequal_stack --> items |
+| `u32_compressed_rshift(8)` | <!-- metric:u32_compressed_rshift_8 -->500<!-- /metric:u32_compressed_rshift_8 --> bytes | <!-- metric:u32_compressed_rshift_8_witness -->6<!-- /metric:u32_compressed_rshift_8_witness --> bytes | <!-- metric:u32_compressed_rshift_8_stack -->5<!-- /metric:u32_compressed_rshift_8_stack --> items |
 | `u32_or(0, 1, 3)` (table excluded) | <!-- metric:u32_or -->326<!-- /metric:u32_or --> bytes | 0 bytes | <!-- metric:u32_or_stack -->272<!-- /metric:u32_or_stack --> items, including table |
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
@@ -44,6 +45,12 @@ Operand witness serialization is deliberately excluded: callers may construct
 words inside the locking script or supply four witness items per word. No
 operation-specific hint is needed. The logic table can be shared by any number
 of XOR, AND, and OR operations in one script.
+
+`u32_compressed_rshift(shift)` accepts one canonical compressed u32 ScriptNum
+and performs a logical right shift for `shift` in `1..=31`. It validates the
+wire encoding, separates the sign-carried high bit from a legal 31-bit
+magnitude, and emits the compressed ScriptNum result. For shift 8, the direct
+fragment is <!-- metric:u32_compressed_rshift_8 -->500<!-- /metric:u32_compressed_rshift_8 --> bytes with a <!-- metric:u32_compressed_rshift_8_witness -->6<!-- /metric:u32_compressed_rshift_8_witness -->-byte one-item witness and a <!-- metric:u32_compressed_rshift_8_stack -->5<!-- /metric:u32_compressed_rshift_8_stack -->-item peak. A decode-byte-shift-reencode baseline costs <!-- metric:u32_compressed_rshift_8_baseline -->499<!-- /metric:u32_compressed_rshift_8_baseline --> bytes and peaks at <!-- metric:u32_compressed_rshift_8_baseline_stack -->7<!-- /metric:u32_compressed_rshift_8_baseline_stack --> items; both measurements exclude input pushes and the terminal predicate.
 
 ## Security
 

--- a/src/arithmetic/u32/mod.rs
+++ b/src/arithmetic/u32/mod.rs
@@ -3,6 +3,7 @@ pub mod and;
 pub mod cmp;
 pub mod or;
 pub mod rotate;
+pub mod shift;
 pub mod stack;
 pub mod sub;
 pub mod xor;

--- a/src/arithmetic/u32/shift.rs
+++ b/src/arithmetic/u32/shift.rs
@@ -1,0 +1,146 @@
+use crate::support::script::*;
+
+fn certify_compressed_word() -> Script {
+    script! {
+        OP_SIZE
+        5
+        OP_NUMEQUAL
+        OP_IF
+            OP_DUP
+            -2147483648
+            OP_EQUALVERIFY
+        OP_ELSE
+            OP_DUP
+            OP_DUP
+            0
+            OP_ADD
+            OP_EQUALVERIFY
+        OP_ENDIF
+        OP_DROP
+    }
+}
+
+fn normalize_compressed_word() -> Script {
+    script! {
+        OP_SIZE 5 OP_NUMEQUAL
+        OP_IF
+            { -2_147_483_648i64 } OP_EQUALVERIFY
+            1 0
+        OP_ELSE
+            OP_DUP
+            0
+            OP_LESSTHAN
+            OP_IF
+                { 0x7fff_ffffu32 } OP_ADD OP_1ADD
+                1 OP_SWAP
+            OP_ELSE
+                0 OP_SWAP
+            OP_ENDIF
+        OP_ENDIF
+    }
+}
+
+fn divide_magnitude_by_power(shift: u32) -> Script {
+    assert!((1..=31).contains(&shift));
+    script! {
+        0 OP_TOALTSTACK
+        if shift < 31 {
+            for bit in (0..=(30 - shift)).rev() {
+                OP_DUP
+                { 1u32 << (shift + bit) }
+                OP_GREATERTHANOREQUAL
+                OP_IF
+                    { 1u32 << (shift + bit) }
+                    OP_SUB
+                    OP_FROMALTSTACK
+                    { 1u32 << bit }
+                    OP_ADD
+                    OP_TOALTSTACK
+                OP_ENDIF
+            }
+        }
+        OP_DROP
+        OP_FROMALTSTACK
+    }
+}
+
+/// Logical right shift of one canonical compressed u32 ScriptNum.
+pub fn u32_compressed_rshift(shift: u32) -> Script {
+    assert!((1..=31).contains(&shift));
+    script! {
+        OP_DUP
+        { certify_compressed_word() }
+        { normalize_compressed_word() }
+        OP_SWAP
+        OP_TOALTSTACK
+        { divide_magnitude_by_power(shift) }
+        OP_FROMALTSTACK
+        OP_IF
+            { 1u32 << (31 - shift) }
+            OP_ADD
+        OP_ENDIF
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::support::execution::execute_script_with_inputs_strict;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha20Rng;
+
+    fn scriptnum(value: u32) -> Vec<u8> {
+        let mut bytes = [0u8; 8];
+        let length = bitcoin::script::write_scriptint(&mut bytes, i64::from(value as i32));
+        bytes[..length].to_vec()
+    }
+
+    #[test]
+    fn test_u32_compressed_rshift_boundaries_and_random_values() {
+        let boundaries = [
+            0,
+            1,
+            0xff,
+            0x100,
+            0x7fff_ffff,
+            0x8000_0000,
+            0xffff_fffe,
+            u32::MAX,
+        ];
+        let mut rng = ChaCha20Rng::seed_from_u64(0x5253_4846);
+        for shift in 1..=31 {
+            for &value in &boundaries {
+                check_shift(value, shift);
+            }
+            for _ in 0..64 {
+                check_shift(rng.gen(), shift);
+            }
+        }
+    }
+
+    #[test]
+    fn test_u32_compressed_rshift_rejects_noncanonical_inputs() {
+        for input in [vec![1, 0], vec![0, 0, 0, 0x80], vec![1, 0, 0, 0, 0]] {
+            let result = execute_script_with_inputs_strict(
+                script! { { u32_compressed_rshift(8) } },
+                vec![input],
+            );
+            assert!(result.error.is_some(), "accepted malformed input: {result}");
+        }
+    }
+
+    fn check_shift(value: u32, shift: u32) {
+        let result = execute_script_with_inputs_strict(
+            script! {
+                { u32_compressed_rshift(shift) }
+                { (value >> shift) as i64 }
+                OP_EQUAL
+            },
+            vec![scriptnum(value)],
+        );
+        assert!(
+            result.success,
+            "compressed right shift failed for {value:08x} >> {shift}: {result}"
+        );
+    }
+}

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -93,6 +93,59 @@ fn max_stack_items_strict(script: bitcoin_script::Script, witness: Vec<Vec<u8>>)
     result.stats.max_nb_stack_items
 }
 
+fn byte_shift8() -> bitcoin_script::Script {
+    script! {
+        OP_TOALTSTACK
+        OP_TOALTSTACK
+        OP_TOALTSTACK
+        OP_TOALTSTACK
+        0
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_DROP
+    }
+}
+
+fn u32_compressed_rshift_metrics() -> Vec<Metric> {
+    const VALUE: u32 = 0x89ab_cdef;
+    let witness = vec![scriptnum(i64::from(VALUE as i32))];
+    let compressed = u32::shift::u32_compressed_rshift(8);
+    let baseline = script! {
+        { u32::stack::u32_uncompress() }
+        { byte_shift8() }
+        { u32::stack::u32_compress() }
+    };
+    vec![
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_rshift_8",
+            value: script_len(compressed.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_rshift_8_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_rshift_8_stack",
+            value: max_stack_items_strict(compressed, witness.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_rshift_8_baseline",
+            value: script_len(baseline.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_rshift_8_baseline_stack",
+            value: max_stack_items_strict(baseline, witness),
+        },
+    ]
+}
+
 fn prince_metrics() -> Vec<Metric> {
     let fragment = prince::prince_encrypt(0);
     let compiled = fragment.clone().compile_with_policy();
@@ -3987,6 +4040,7 @@ fn metrics() -> Vec<Metric> {
         },
     ]
     .into_iter()
+    .chain(u32_compressed_rshift_metrics())
     .chain(prince_metrics())
     .chain(winternitz_metrics())
     .chain(winternitz_sha256_metrics())
@@ -4035,6 +4089,11 @@ fn winternitz20_metrics_are_current() {
 #[test]
 fn prince_metrics_are_current() {
     check_readme_metrics(prince_metrics());
+}
+
+#[test]
+fn u32_compressed_rshift_metrics_are_current() {
+    check_readme_metrics(u32_compressed_rshift_metrics());
 }
 
 /// This isolated fixture exercises only the two small packed decoders. It


### PR DESCRIPTION
## Summary

- add `u32_compressed_rshift(shift)` for canonical compressed u32 ScriptNums, supporting shifts `1..=31`
- validate hostile compressed encodings, normalize the sign-carried high bit and 31-bit magnitude, divide by a compile-time power of two, and restore logical shift semantics
- document the OP-014 progress, measurements, comparison baseline, and remaining Core-validation gap

## Measurements

For shift 8:

- direct compressed fragment: 500 locking bytes, 6 representative witness bytes, 1 witness item, 5-item peak
- decode-byte-shift-reencode baseline: 499 locking bytes, 6 representative witness bytes, 1 witness item, 7-item peak
- the direct construction is a stack-shape tradeoff, not a general locking-byte win

## Verification

- `python3 tools/kb.py validate`
- `cargo fmt --all -- --check`
- `cargo test --locked u32_compressed_rshift --lib`
- `cargo test --locked --test primitive_metrics u32_compressed_rshift_metrics_are_current`
- `cargo run --locked --release --example u32_compressed_rshift_benchmark`
- `git diff --check`

The full repository test suite was intentionally not run; verification was scoped to the new primitive and its metrics. OP-014 remains open for complete transaction and pinned Bitcoin Core differential validation.
