### PR TITLE
feat(arithmetic): add compressed u32 logical left shift

### DIFF
--- a/examples/u32_compressed_lshift_benchmark.rs
+++ b/examples/u32_compressed_lshift_benchmark.rs
@@ -1,0 +1,71 @@
+use bitcoin::consensus::encode::serialize;
+use bitcoin::script::Instruction;
+use bitcoin::Witness;
+use bitcoin_lab::arithmetic::u32::shift::u32_compressed_lshift;
+use bitcoin_lab::arithmetic::u32::stack::{u32_compress, u32_uncompress};
+use bitcoin_lab::support::execution::execute_raw_script_with_inputs_strict;
+use bitcoin_lab::support::script::{Script, ScriptCompilation};
+use bitcoin_script::script;
+
+fn scriptnum(value: u32) -> Vec<u8> {
+    let mut bytes = [0u8; 8];
+    let length = bitcoin::script::write_scriptint(&mut bytes, i64::from(value as i32));
+    bytes[..length].to_vec()
+}
+
+fn byte_lshift8() -> Script {
+    script! {
+        OP_TOALTSTACK
+        OP_TOALTSTACK
+        OP_TOALTSTACK
+        OP_TOALTSTACK
+        OP_FROMALTSTACK
+        OP_DROP
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        0
+    }
+}
+
+fn measure(name: &str, script: Script, witness: Vec<Vec<u8>>) {
+    let leaf = script! {
+        { script }
+        OP_VERIFY
+        OP_TRUE
+    }
+    .compile_with_policy();
+    let result = execute_raw_script_with_inputs_strict(leaf.to_bytes(), witness);
+    assert!(result.success, "{name} failed: {result}");
+    let static_non_push_opcodes = leaf
+        .instructions()
+        .map(|instruction| instruction.expect("generated benchmark script must parse"))
+        .filter(|instruction| !matches!(instruction, Instruction::PushBytes(_)))
+        .count();
+    println!("{name}_script_bytes={}", leaf.len());
+    println!(
+        "{name}_witness_bytes={}",
+        serialize(&Witness::from_slice(&[scriptnum(0x1234_5678)])).len()
+    );
+    println!("{name}_witness_data_items=1");
+    println!("{name}_hint_items=0");
+    println!("{name}_stack_peak={}", result.stats.max_nb_stack_items);
+    println!("{name}_executed_opcodes=null");
+    println!("{name}_static_non_push_opcodes={static_non_push_opcodes}");
+    println!(
+        "{name}_validation_weight_delta={}",
+        result.stats.validation_weight
+    );
+}
+
+fn main() {
+    const VALUE: u32 = 0x1234_5678;
+    let witness = vec![scriptnum(VALUE)];
+    measure("compressed", u32_compressed_lshift(8), witness.clone());
+    measure(
+        "decode_shift_encode_baseline",
+        script! { { u32_uncompress() } { byte_lshift8() } { u32_compress() } },
+        witness,
+    );
+    println!("context=tapscript stack_limit=1000");
+}

--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1,8 +1,97 @@
 {
   "schema_version": 1,
-  "as_of": "2026-09-01",
+  "as_of": "2026-09-11",
   "cost_model": "knowledge/cost-model.md",
   "records": [
+    {
+      "id": "arithmetic/u32-compressed-lshift",
+      "name": "Compressed total-domain u32 logical left shift",
+      "class": "arithmetic/word",
+      "summary": "Canonical one-item ScriptNum adapter for modulo-2^32 logical u32 left shifts.",
+      "status": "experimental",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/u32-compressed-lshift.md",
+      "implementation": "src/arithmetic/u32/shift.rs",
+      "documentation": "src/arithmetic/u32/README.md",
+      "tests": [
+        "arithmetic::u32::shift::tests::test_u32_compressed_lshift_boundaries_and_random_values",
+        "arithmetic::u32::shift::tests::test_u32_compressed_lshift_rejects_noncanonical_inputs",
+        "primitive_metrics::u32_compressed_lshift_metrics_are_current",
+        "examples/u32_compressed_lshift_benchmark.rs"
+      ],
+      "references": [
+        "bip-342",
+        "bitcoin-script-locked",
+        "bitcoin-scriptexec-locked"
+      ],
+      "techniques": [
+        "digit-arithmetic",
+        "metadata-carrier"
+      ],
+      "security": "No independent cryptographic claim. The compressed input is hostile and must pass exact canonical-wire checks before sign/magnitude normalization; complete protocol binding and deployment validation remain open.",
+      "stack_contract": "... word -> ... ((word << shift) mod 2^32); shift is 1..=31, the input is consumed, and unrelated lower stack state is preserved.",
+      "configurations": [
+        {
+          "id": "shift-8-direct",
+          "label": "Direct compressed logical left shift by 8",
+          "parameters": {
+            "shift": 8,
+            "value": "0x12345678",
+            "hint_items_per_invocation": 0,
+            "complete_input_items": 1
+          },
+          "includes": "fragment-with-memory: canonical-wire check, sign/magnitude normalization, repeated doubling, and recentering; excludes input push, terminal predicate, transaction framing, and unrelated live state",
+          "script_bytes": 492,
+          "witness_bytes": 6,
+          "witness_bytes_max": 7,
+          "max_stack_items": 5,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 492,
+          "metric_keys": [
+            "u32_compressed_lshift_8",
+            "u32_compressed_lshift_8_witness",
+            "u32_compressed_lshift_8_stack"
+          ]
+        },
+        {
+          "id": "shift-8-decode-baseline",
+          "label": "Decode, byte-shift, and re-encode baseline",
+          "parameters": {
+            "shift": 8,
+            "value": "0x12345678",
+            "complete_input_items": 1
+          },
+          "includes": "fragment-only: existing compressed decoder, four-item byte shift, and existing encoder; excludes input push, terminal predicate, transaction framing, and unrelated live state",
+          "script_bytes": 490,
+          "witness_bytes": 6,
+          "witness_bytes_max": 7,
+          "max_stack_items": 7,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 490,
+          "metric_keys": [
+            "u32_compressed_lshift_8_baseline",
+            "u32_compressed_lshift_8_witness",
+            "u32_compressed_lshift_8_baseline_stack"
+          ]
+        }
+      ],
+      "limitations": [
+        "Shift-ladder size varies with the compile-time shift",
+        "Dominated by the local baseline for shift-8 locking-script bytes",
+        "Bitcoin Core, complete-transaction, relay-policy, and canonical witness-policy validation remain open"
+      ],
+      "open_problems": [
+        "OP-002",
+        "OP-003",
+        "OP-020"
+      ]
+    },
     {
       "id": "arithmetic/scriptnum-constant-mul",
       "name": "ScriptNum constant multiplication",

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -18,6 +18,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Native secp256k1 base-field square | 29 balanced radix-512 digits, symmetry-specialized | 14,541 | 94-byte/67-item incremental hint; certified operand; 614-item strict peak |
 | Three native secp256k1 ordinary multiplies | Shared table, destructive third-gate recombination | 59,163 | 280-byte/201-item incremental hint; 993-item strict peak; unoptimized above cutoff |
 | Bounded RNS add | Legacy RNS add | 216 | Modulo 69,300 |
+| Compressed u32 logical left shift | Direct one-item ScriptNum shift by 8 | 492 | 1 witness item; 5-item peak; decode baseline 490 bytes / 7-item peak |
 | Bounded RNS multiply | Legacy RNS multiply | 1,561 | 903-item peak |
 | Exact 256-bit-product RNS add | 75-prime canonical coordinatewise | 1,131 | 513-bit composite range; 151-item peak |
 | Exact 256-by-256-bit RNS multiply baseline | 75-prime table/Horner hybrid | 15,624 | No relation carries; 183-item peak |

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -6,7 +6,7 @@ reproducible constructions. The local Rust library is one source of evidence;
 it is not the boundary of the atlas.
 
 The catalog is explicitly time-scoped. Its current review date is
-**2026-09-04**. A record's `as_of` field says when its claims were last checked.
+**2026-09-11**. A record's `as_of` field says when its claims were last checked.
 Missing records are unknown coverage, not proof of nonexistence.
 
 ## How to answer a research question

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,13 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+
+## NR-044: Direct compressed u32 left shift is not a byte win
+
+`u32_compressed_lshift(8)` performs a total-domain modulo-`2^32` left shift
+directly over one canonical ScriptNum, but costs 492 locking bytes versus 490
+for a local decode-byte-shift-reencode baseline. It saves two live stack items,
+peaking at 5 instead of 7, with the same one-item witness. The construction is
+retained as a stack-shape primitive and a complete-width correctness result,
+not as a general script-byte optimization. Evidence is `locally-reproduced`;
+deployment is `unclassified`; OP-020 remains open.

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -293,6 +293,21 @@ setup, script bytes, executed opcodes, and strict stack peaks are compared on
 the same boundary; malformed encodings are rejected; and a complete tapscript
 leaf is differentially validated against a pinned Bitcoin Core revision.
 
+## OP-020 — Total-domain compressed-u32 shift pair
+
+Determine whether a canonical one-item compressed u32 representation can
+provide both logical shifts as a composable alternative to byte expansion.
+**Complete when:** left and right shifts `1..=31` have like-for-like input and
+output conversion costs, executed-opcode and strict combined-stack metrics,
+malformed-wire rejection, complete tapscript leaves, and pinned Bitcoin Core
+differential validation; any shift width dominated by byte expansion is
+recorded rather than omitted.
+
+Progress: deterministic local left-shift tests cover all widths and the direct
+shift-8 fragment measures 492 bytes and five stack items versus a 490-byte,
+seven-item local decode/shift/re-encode baseline. The result is a stack-shape
+tradeoff, not a byte win, and the deployment criterion remains open.
+
 ## OP-015 — Native secp256k1 field circuit frontier
 
 Turn the native 20,503-byte ordinary multiplication, 20,450-byte factor-16

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -10,6 +10,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [Hinted ScriptNum division](scriptnum-hinted-div.md)
 - [u4 digit arithmetic](u4.md)
 - [u32 word arithmetic](u32.md)
+- [Compressed total-domain u32 logical left shift](u32-compressed-lshift.md)
 - [u31 prime-field arithmetic](u31.md)
 - [Native secp256k1 base-field arithmetic](secp256k1-field.md)
 - [Ed25519 base-field multiplication](ed25519-field.md)

--- a/knowledge/primitives/u32-compressed-lshift.md
+++ b/knowledge/primitives/u32-compressed-lshift.md
@@ -1,0 +1,62 @@
+# Compressed total-domain u32 logical left shift
+
+## Research question
+
+Can a canonical one-item compressed u32 ScriptNum implement a modulo-`2^32`
+logical left shift without expanding into four byte limbs?
+
+## Hypothesis and threat model
+
+The sign-carried high bit is irrelevant after any nonzero left shift. If the
+remaining 31-bit magnitude is doubled repeatedly and recentered whenever it
+crosses `2^30`, the result can remain a canonical compressed ScriptNum at each
+step. The witness input is hostile and must pass the exact compressed-wire
+check; there is no cryptographic security claim and no auxiliary hint.
+
+## Construction
+
+`u32_compressed_lshift(shift)` supports `shift` in `1..=31`. It validates the
+input, extracts the lower 31-bit magnitude, and applies a compile-time number
+of checked doublings. A doubling below `2^30` remains positive. A doubling at
+or above that threshold is reduced modulo `2^32` and represented as the
+corresponding negative ScriptNum, which is normalized before the next step.
+
+The fragment contract is:
+
+```text
+... word -> ... ((word << shift) mod 2^32)
+```
+
+## Measured boundary
+
+Measurements use policy compilation and strict local `bitcoin-scriptexec` in a
+tapscript context with the 1,000-item stack limit. They exclude input pushes,
+the terminal predicate, transaction framing, and unrelated live state.
+
+| Configuration | Script bytes | Witness bytes | Data items | Peak |
+| --- | ---: | ---: | ---: | ---: |
+| Direct compressed shift by 8 | 492 | 6 representative / 7 sentinel-boundary maximum | 1 | 5 |
+| Decode, byte-shift, re-encode baseline | 490 | 6 representative / 7 sentinel-boundary maximum | 1 | 7 |
+
+The direct construction is two bytes larger at shift 8 but saves two live
+stack items. It is therefore a stack-shape primitive and a useful compressed
+representation experiment, not a general locking-byte improvement. Generated
+script size varies with the requested shift.
+
+## Evidence and limitations
+
+Evidence is `locally-reproduced`; deployment is `unclassified`. Deterministic
+boundary tests cover every shift in `1..=31`; deterministic random vectors
+cover selected widths, and malformed, negative-zero, and padded inputs are
+rejected. The baseline is an executable local composition of the existing
+compressed decoder, a four-byte shift-by-8 adapter, and the existing encoder;
+it is not an independent Core implementation. Complete transaction, policy,
+and pinned Bitcoin Core differential validation remain open under OP-002,
+OP-003, and OP-020.
+
+Reproduce with:
+
+```sh
+cargo test --locked u32_compressed_lshift --lib
+cargo run --locked --release --example u32_compressed_lshift_benchmark
+```

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -15,3 +15,6 @@ stack manipulation.
 See the [implementation README](../../src/arithmetic/u32/README.md),
 [technique page](../techniques/representations.md), and catalog record
 `arithmetic/u32`.
+
+The one-item compressed-domain left-shift experiment is documented separately
+in [compressed logical left shift](u32-compressed-lshift.md).

--- a/research/u32-compressed-lshift/README.md
+++ b/research/u32-compressed-lshift/README.md
@@ -1,0 +1,22 @@
+# Compressed u32 logical left shift
+
+This experiment evaluates direct modulo-`2^32` left shifts over the
+repository's one-item compressed u32 representation. It checks canonical
+ScriptNum wire encodings, removes the sign-carried high bit for nonzero
+shifts, repeatedly doubles the safe 31-bit magnitude, and re-centers overflow
+as a negative compressed ScriptNum.
+
+At shift 8, the direct fragment is 492 locking bytes, uses one six-byte
+serialized witness item, and peaks at five stack items. The local
+decode-byte-shift-reencode baseline is 490 bytes with the same witness and a
+seven-item peak. The sentinel-boundary witness is seven serialized bytes.
+
+Run:
+
+```sh
+cargo test --locked u32_compressed_lshift --lib
+cargo run --locked --release --example u32_compressed_lshift_benchmark
+```
+
+Results are locally reproduced under strict tapscript execution. They are not
+Bitcoin Core or relay-policy validation.

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -35,6 +35,7 @@ as less-than-or-equal.
 | `u32_sub_drop(0, 1)` | <!-- metric:u32_sub_drop -->77<!-- /metric:u32_sub_drop --> bytes | 0 bytes | <!-- metric:u32_sub_drop_stack -->9<!-- /metric:u32_sub_drop_stack --> items |
 | `u32_lessthan()` | <!-- metric:u32_lessthan -->38<!-- /metric:u32_lessthan --> bytes | 0 bytes | <!-- metric:u32_lessthan_stack -->9<!-- /metric:u32_lessthan_stack --> items |
 | `u32_lessthanorequal()` | <!-- metric:u32_lessthanorequal -->61<!-- /metric:u32_lessthanorequal --> bytes | 0 bytes | <!-- metric:u32_lessthanorequal_stack -->13<!-- /metric:u32_lessthanorequal_stack --> items |
+| `u32_compressed_lshift(8)` | <!-- metric:u32_compressed_lshift_8 -->492<!-- /metric:u32_compressed_lshift_8 --> bytes | <!-- metric:u32_compressed_lshift_8_witness -->6<!-- /metric:u32_compressed_lshift_8_witness --> bytes | <!-- metric:u32_compressed_lshift_8_stack -->5<!-- /metric:u32_compressed_lshift_8_stack --> items |
 | `u32_or(0, 1, 3)` (table excluded) | <!-- metric:u32_or -->326<!-- /metric:u32_or --> bytes | 0 bytes | <!-- metric:u32_or_stack -->272<!-- /metric:u32_or_stack --> items, including table |
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
@@ -44,6 +45,12 @@ Operand witness serialization is deliberately excluded: callers may construct
 words inside the locking script or supply four witness items per word. No
 operation-specific hint is needed. The logic table can be shared by any number
 of XOR, AND, and OR operations in one script.
+
+`u32_compressed_lshift(shift)` accepts one canonical compressed u32 ScriptNum
+and performs a modulo-`2^32` logical left shift for `shift` in `1..=31`. It
+validates the wire encoding, discards the shifted-out sign-carried bit, and
+re-encodes each doubled magnitude without leaving the four-byte expansion live.
+For shift 8, the direct fragment is <!-- metric:u32_compressed_lshift_8 -->492<!-- /metric:u32_compressed_lshift_8 --> bytes with a <!-- metric:u32_compressed_lshift_8_witness -->6<!-- /metric:u32_compressed_lshift_8_witness -->-byte one-item witness and a <!-- metric:u32_compressed_lshift_8_stack -->5<!-- /metric:u32_compressed_lshift_8_stack -->-item peak. A decode-byte-shift-reencode baseline costs <!-- metric:u32_compressed_lshift_8_baseline -->490<!-- /metric:u32_compressed_lshift_8_baseline --> bytes and peaks at <!-- metric:u32_compressed_lshift_8_baseline_stack -->7<!-- /metric:u32_compressed_lshift_8_baseline_stack --> items; both measurements exclude input pushes and the terminal predicate.
 
 ## Security
 

--- a/src/arithmetic/u32/mod.rs
+++ b/src/arithmetic/u32/mod.rs
@@ -3,6 +3,7 @@ pub mod and;
 pub mod cmp;
 pub mod or;
 pub mod rotate;
+pub mod shift;
 pub mod stack;
 pub mod sub;
 pub mod xor;

--- a/src/arithmetic/u32/shift.rs
+++ b/src/arithmetic/u32/shift.rs
@@ -1,0 +1,153 @@
+use crate::support::script::*;
+
+fn certify_compressed_word() -> Script {
+    script! {
+        OP_SIZE
+        5
+        OP_NUMEQUAL
+        OP_IF
+            OP_DUP
+            -2147483648
+            OP_EQUALVERIFY
+        OP_ELSE
+            OP_DUP
+            OP_DUP
+            0
+            OP_ADD
+            OP_EQUALVERIFY
+        OP_ENDIF
+        OP_DROP
+    }
+}
+
+fn normalize_compressed_word() -> Script {
+    script! {
+        OP_SIZE 5 OP_NUMEQUAL
+        OP_IF
+            { -2_147_483_648i64 } OP_EQUALVERIFY
+            1 0
+        OP_ELSE
+            OP_DUP
+            0
+            OP_LESSTHAN
+            OP_IF
+                { 0x7fff_ffffu32 } OP_ADD OP_1ADD
+                1 OP_SWAP
+            OP_ELSE
+                0 OP_SWAP
+            OP_ENDIF
+        OP_ENDIF
+    }
+}
+
+fn double_magnitude() -> Script {
+    script! {
+        OP_DUP
+        { 0x4000_0000u32 }
+        OP_GREATERTHANOREQUAL
+        OP_IF
+            { 0x4000_0000u32 }
+            OP_SUB
+            OP_DUP
+            OP_ADD
+            { 0x7fff_ffffu32 }
+            OP_SUB
+            OP_1SUB
+        OP_ELSE
+            OP_DUP
+            OP_ADD
+        OP_ENDIF
+    }
+}
+
+/// Logical left shift of one canonical compressed u32 ScriptNum.
+pub fn u32_compressed_lshift(shift: u32) -> Script {
+    assert!((1..=31).contains(&shift));
+    script! {
+        OP_DUP
+        { certify_compressed_word() }
+        { normalize_compressed_word() }
+        OP_SWAP
+        OP_DROP
+        for index in 0..shift {
+            { double_magnitude() }
+            if index + 1 < shift {
+                { normalize_compressed_word() }
+                OP_SWAP
+                OP_DROP
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::support::execution::execute_raw_script_with_inputs_strict;
+    use crate::support::script::ScriptCompilation;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha20Rng;
+
+    fn scriptnum(value: u32) -> Vec<u8> {
+        let mut bytes = [0u8; 8];
+        let length = bitcoin::script::write_scriptint(&mut bytes, i64::from(value as i32));
+        bytes[..length].to_vec()
+    }
+
+    #[test]
+    fn test_u32_compressed_lshift_boundaries_and_random_values() {
+        let boundaries = [
+            0,
+            1,
+            0xff,
+            0x100,
+            0x4000_0000,
+            0x7fff_ffff,
+            0x8000_0000,
+            0xffff_fffe,
+            u32::MAX,
+        ];
+        let mut rng = ChaCha20Rng::seed_from_u64(0x4c53_4846);
+        for shift in 1..=31 {
+            let script = script! {
+                { u32_compressed_lshift(shift) }
+            }
+            .compile_with_policy()
+            .to_bytes();
+            for &value in &boundaries {
+                check_shift(&script, value, shift);
+            }
+            if matches!(shift, 1 | 2 | 7 | 8 | 15 | 16 | 23 | 31) {
+                for _ in 0..16 {
+                    check_shift(&script, rng.gen(), shift);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_u32_compressed_lshift_rejects_noncanonical_inputs() {
+        for input in [vec![1, 0], vec![0, 0, 0, 0x80], vec![1, 0, 0, 0, 0]] {
+            let result = execute_raw_script_with_inputs_strict(
+                script! { { u32_compressed_lshift(8) } }
+                    .compile_with_policy()
+                    .to_bytes(),
+                vec![input],
+            );
+            assert!(result.error.is_some(), "accepted malformed input: {result}");
+        }
+    }
+
+    fn check_shift(script: &[u8], value: u32, shift: u32) {
+        let result = execute_raw_script_with_inputs_strict(script.to_vec(), vec![scriptnum(value)]);
+        assert!(
+            result.error.is_none(),
+            "compressed left shift failed for {value:08x} << {shift}: {result}"
+        );
+        assert_eq!(
+            result.final_stack.get(0),
+            scriptnum((value << shift) as u32),
+            "wrong compressed output for {value:08x} << {shift}: {result}"
+        );
+    }
+}

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -93,6 +93,59 @@ fn max_stack_items_strict(script: bitcoin_script::Script, witness: Vec<Vec<u8>>)
     result.stats.max_nb_stack_items
 }
 
+fn byte_lshift8() -> bitcoin_script::Script {
+    script! {
+        OP_TOALTSTACK
+        OP_TOALTSTACK
+        OP_TOALTSTACK
+        OP_TOALTSTACK
+        OP_FROMALTSTACK
+        OP_DROP
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK
+        0
+    }
+}
+
+fn u32_compressed_lshift_metrics() -> Vec<Metric> {
+    const VALUE: u32 = 0x1234_5678;
+    let witness = vec![scriptnum(i64::from(VALUE as i32))];
+    let compressed = u32::shift::u32_compressed_lshift(8);
+    let baseline = script! {
+        { u32::stack::u32_uncompress() }
+        { byte_lshift8() }
+        { u32::stack::u32_compress() }
+    };
+    vec![
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_lshift_8",
+            value: script_len(compressed.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_lshift_8_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_lshift_8_stack",
+            value: max_stack_items_strict(compressed, witness.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_lshift_8_baseline",
+            value: script_len(baseline.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_compressed_lshift_8_baseline_stack",
+            value: max_stack_items_strict(baseline, witness),
+        },
+    ]
+}
+
 fn prince_metrics() -> Vec<Metric> {
     let fragment = prince::prince_encrypt(0);
     let compiled = fragment.clone().compile_with_policy();
@@ -3987,6 +4040,7 @@ fn metrics() -> Vec<Metric> {
         },
     ]
     .into_iter()
+    .chain(u32_compressed_lshift_metrics())
     .chain(prince_metrics())
     .chain(winternitz_metrics())
     .chain(winternitz_sha256_metrics())
@@ -4035,6 +4089,11 @@ fn winternitz20_metrics_are_current() {
 #[test]
 fn prince_metrics_are_current() {
     check_readme_metrics(prince_metrics());
+}
+
+#[test]
+fn u32_compressed_lshift_metrics_are_current() {
+    check_readme_metrics(u32_compressed_lshift_metrics());
 }
 
 /// This isolated fixture exercises only the two small packed decoders. It


### PR DESCRIPTION
## Summary

- add `u32_compressed_lshift(shift)` for canonical compressed u32 ScriptNums, supporting shifts `1..=31`
- validate hostile compressed encodings, extract the safe 31-bit magnitude, repeatedly double with signed recentering, and return the modulo-`2^32` compressed result
- record the full-width correctness result and the OP-020 frontier, including the dominated-byte comparison

## Measurements

For shift 8:

- direct compressed fragment: 492 locking bytes, 6 representative witness bytes, 1 witness item, 5-item peak
- decode-byte-shift-reencode baseline: 490 locking bytes, 6 representative witness bytes, 1 witness item, 7-item peak
- the direct construction costs 2 locking bytes but saves 2 live stack items

## Verification

- `python3 tools/kb.py validate`
- `cargo fmt --all -- --check`
- `cargo test --locked u32_compressed_lshift --lib`
- `cargo test --locked --test primitive_metrics u32_compressed_lshift_metrics_are_current`
- `cargo run --locked --release --example u32_compressed_lshift_benchmark`
- `git diff --check`

The full repository test suite was intentionally not run; verification was scoped to the new primitive and its metrics. Deployment remains `unclassified`; no Bitcoin Core or relay-policy claim is made.
