### PR TITLE
feat(commitments): add ternary mixed-hash integer path

### DIFF
--- a/examples/ternary_hash_path_benchmark.rs
+++ b/examples/ternary_hash_path_benchmark.rs
@@ -1,0 +1,32 @@
+use bitcoin::consensus::encode::serialize;
+use bitcoin::Witness;
+use bitcoin_lab::commitments::{
+    ternary_hash_path_integer_commitment, ternary_hash_path_integer_witness,
+    verify_ternary_hash_path_to_integer,
+};
+use bitcoin_lab::support::execution::execute_script_with_inputs_strict;
+use bitcoin_lab::support::script::ScriptCompilation;
+
+fn main() {
+    let preimage = [0x42; 32];
+    let value = 0x1234_5678;
+    let commitment = ternary_hash_path_integer_commitment(&preimage, value, 31);
+    let witness = ternary_hash_path_integer_witness(&preimage, value, 31);
+    let verifier = verify_ternary_hash_path_to_integer(31, commitment);
+    let execution = execute_script_with_inputs_strict(verifier.clone(), witness.clone());
+    assert!(execution.success, "benchmark fixture failed: {execution}");
+    let script_bytes = verifier.compile_with_policy().len();
+
+    println!("primitive=ternary_hash_path_integer");
+    println!("bit_width=31");
+    println!("trit_count=20");
+    println!("script_bytes={script_bytes}");
+    println!(
+        "witness_bytes={}",
+        serialize(&Witness::from_slice(&witness)).len()
+    );
+    println!("witness_items={}", witness.len());
+    println!("hint_items=0");
+    println!("executed_opcodes={}", execution.stats.opcode_count);
+    println!("commitment_bytes={}", commitment.len());
+}

--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "as_of": "2026-09-01",
+  "as_of": "2026-09-11",
   "cost_model": "knowledge/cost-model.md",
   "records": [
     {
@@ -1497,6 +1497,75 @@
       "open_problems": [
         "OP-003",
         "OP-004"
+      ]
+    },
+    {
+      "id": "commitment/ternary-hash-path-integer",
+      "name": "Ternary mixed-hash integer path",
+      "class": "commitment/integer",
+      "summary": "Authenticates canonical base-3 trits with fixed-length SHA-256/RIPEMD-160 codewords and reconstructs a 1–31-bit integer.",
+      "status": "experimental",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/ternary-hash-path-integer.md",
+      "implementation": "src/commitments/ternary_hash_path.rs",
+      "documentation": "src/commitments/README.md",
+      "tests": [
+        "commitments::ternary_hash_path::tests::verifies_all_ternary_codewords",
+        "commitments::ternary_hash_path::tests::verifies_integer_boundaries_and_values",
+        "commitments::ternary_hash_path::tests::rejects_wrong_openings_and_noncanonical_trits",
+        "commitments::ternary_hash_path::tests::rejects_out_of_range_generic_trits",
+        "primitive_metrics::ternary_hash_path_metrics_are_current",
+        "examples/ternary_hash_path_benchmark.rs"
+      ],
+      "references": [
+        "bip-342",
+        "bitcoin-scriptexec-locked",
+        "bitcoin-script-locked",
+        "fips-180-4"
+      ],
+      "techniques": [
+        "mixed-hash-path"
+      ],
+      "security": "The final RIPEMD-160 digest limits generic collision resistance to 80 bits; hiding requires min-entropy in the unrevealed preimage/trits, and binding assumes the non-standard three-codeword mixed-hash schedule.",
+      "stack_contract": "... tritN-1 ... trit0 preimage -> ... value",
+      "configurations": [
+        {
+          "id": "integer-31",
+          "label": "31-bit ternary integer path",
+          "parameters": {
+            "bit_width": 31,
+            "trit_count": 20,
+            "preimage_bytes": 32
+          },
+          "includes": "fragment-only: verifier and base-3 integer reconstruction; witness includes serialized trits and preimage",
+          "script_bytes": 924,
+          "witness_bytes": 63,
+          "witness_bytes_max": 63,
+          "max_stack_items": 24,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 924,
+          "metric_keys": [
+            "ternary_hash_path_integer_31",
+            "ternary_hash_path_integer_witness_31",
+            "ternary_hash_path_integer_stack_31"
+          ]
+        }
+      ],
+      "limitations": [
+        "Non-standard mixed-hash construction without dedicated cryptanalysis",
+        "Integer reconstruction limited to 31 bits and 20 trits at that width",
+        "Dominated by the measured four-way path for ordinary 31-bit integer bytes and stack usage",
+        "All trits coexist at script entry; surrounding protocol state must be charged against the 1,000-item stack limit",
+        "Bitcoin Core consensus and policy validation not performed"
+      ],
+      "open_problems": [
+        "OP-002",
+        "OP-003",
+        "OP-020"
       ]
     },
     {

--- a/knowledge/comparisons/commitments.md
+++ b/knowledge/comparisons/commitments.md
@@ -4,7 +4,8 @@
 | --- | --- | ---: | ---: | ---: | --- |
 | Preimage length | `len(preimage)-offset` | 44 | 18–524 | 3 | Range coupled to item size |
 | Mixed hash path | 31 authenticated bits | 520 | 78 | 34 | Mixed-hash assumption; wider opcode cost |
-| Four-way mixed hash path | 16 authenticated base-4 digits / 31 bits | 453 | 61 | 19 | Tapscript `MINIMALIF` required; non-standard mixed-hash code |
+| Four-way mixed hash path | 16 authenticated base-4 digits / 31 bits | 438 | 61 | 19 | Tapscript `MINIMALIF` required; non-standard mixed-hash code |
+| Ternary mixed hash path | 20 authenticated base-3 trits / 31 bits | 924 | 63 | 24 | Native ternary state encoding; larger than four-way path |
 | Lamport 2-bit | Select one of four preimages | 96 | 11 | small | Strictly one-time |
 
 The schemes have different semantics. Preimage length is compact but encodes
@@ -14,3 +15,9 @@ the four-way path saves 67 script bytes, 17 witness bytes, and 15 peak stack
 items relative to the binary path. This comparison does not erase its stronger
 tapscript-only execution assumption or its non-standard mixed-hash security
 assumption.
+
+The ternary path is not a byte-efficiency improvement for this integer target:
+it uses one more witness item than the four-way path and is 486 bytes larger.
+It is retained as a different representation point for protocols whose state
+is naturally three-valued. Its local implementation performs explicit trit
+canonicality checks instead of relying on tapscript `MINIMALIF`.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -6,7 +6,7 @@ reproducible constructions. The local Rust library is one source of evidence;
 it is not the boundary of the atlas.
 
 The catalog is explicitly time-scoped. Its current review date is
-**2026-09-04**. A record's `as_of` field says when its claims were last checked.
+**2026-09-11**. A record's `as_of` field says when its claims were last checked.
 Missing records are unknown coverage, not proof of nonexistence.
 
 ## How to answer a research question

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,13 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+## NR-043: Ternary mixed-hash paths lose to four-way integer paths
+
+The ternary path was implemented as a native three-valued alternative using
+`0 -> SS`, `1 -> SR`, and `2 -> RS`, with explicit canonical trit checks. At
+31 bits and a 32-byte preimage it measures 924 script bytes, 63 serialized
+witness bytes, and a 24-item peak, versus 438/61/19 for the four-way path.
+It is therefore dominated for the measured ordinary integer objective and is
+not retained as a byte-efficiency improvement. The result does not rule out a
+ternary path when protocol state is naturally three-valued or when a different
+consumer amortizes its dispatcher.

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -3,6 +3,16 @@
 Each problem has a falsifiable completion criterion. Update comparisons and
 negative results when closing one.
 
+## OP-020 — Ternary commitment composition frontier
+
+Determine whether the ternary mixed-hash path becomes useful when a protocol
+consumes native three-valued state rather than reconstructing an ordinary
+integer. **Complete when:** at least one ternary protocol composition is
+implemented with its terminal predicates and surrounding state, compared on a
+like-for-like boundary against binary and four-way alternatives, and the
+three-codeword mixed-hash binding assumption receives an independent analysis
+or a pinned Core differential fixture.
+
 ## OP-019 — PRINCEv2 M-hat circuit frontier
 
 Find a smaller repeated M-hat circuit for generation-time-key encryption.

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -23,6 +23,7 @@ the source. Read a page together with its comparison page and evidence record.
 
 - [Mixed-hash path commitment](hash-path-integer.md)
 - [Four-way mixed-hash integer path](four-way-hash-path-integer.md)
+- [Ternary mixed-hash integer path](ternary-hash-path-integer.md)
 - [Preimage-length integer](preimage-length.md)
 - [Binohash transaction digest](binohash.md)
 

--- a/knowledge/primitives/ternary-hash-path-integer.md
+++ b/knowledge/primitives/ternary-hash-path-integer.md
@@ -1,0 +1,72 @@
+# Ternary mixed-hash integer path
+
+Authenticates fixed-width base-3 digits with three fixed-length SHA-256/
+RIPEMD-160 codewords and reconstructs a 1–31-bit non-negative Script integer.
+
+## Question and hypothesis
+
+Can a canonical three-valued hash path provide a useful middle point for
+protocol state that is naturally ternary, while remaining within Bitcoin
+Script's per-item and combined-stack limits? The hypothesis was that explicit
+trit validation would make the representation composable even if its ordinary
+31-bit integer cost lost to the existing binary and four-way paths.
+
+## Construction
+
+Let `S` be SHA-256 and `R` be RIPEMD-160. Each trit selects exactly two hashes:
+
+```text
+0 -> SS    1 -> SR    2 -> RS
+```
+
+`RR` is deliberately unused. The path processes least-significant trits
+first, finishes with `R`, and compares the resulting 20-byte commitment. The
+integer adapter uses the smallest fixed number of base-3 digits covering the
+requested width; 31 bits require 20 trits. Witness order is
+`tritN-1 ... trit0 preimage`, with zero encoded as the empty vector and the
+other trits as exactly `[01]` or `[02]`.
+
+The Script fragment explicitly rejects padded, negative-zero, and out-of-range
+trit encodings. It then reconstructs the committed value as
+`3*acc + trit` while draining the saved trits from the altstack.
+
+## Evidence and representative cost
+
+Evidence is `locally-reproduced`: all three codewords, integer boundaries,
+wrong openings, non-canonical encodings, and out-of-range trits pass focused
+tests. The local tests use the strict tapscript-context executor; no Bitcoin
+Core consensus or relay-policy comparison has been performed, so deployment is
+`unclassified`.
+
+For a 32-byte preimage and a 31-bit value:
+
+| Fragment | Script bytes | Serialized witness | Witness items | Peak items |
+| --- | ---: | ---: | ---: | ---: |
+| `verify_ternary_hash_path_to_integer` | 924 | 63 | 21 | 24 |
+
+The benchmark reports zero auxiliary hint items. These are fragment-only
+measurements: the verifier and integer reconstruction are included, while
+input pushes, terminal predicates, and transaction framing are excluded.
+The strict local tapscript benchmark's legacy `opcode_count` reports `0`, so
+executed-opcode count remains unavailable rather than being inferred from the
+static script.
+
+The construction is larger than the measured four-way path (438 bytes, 61
+witness bytes, 19 peak items) for ordinary 31-bit integers. Its value is the
+native three-way selector, not a claim of Pareto improvement.
+
+## Security and deployment
+
+The final RIPEMD-160 digest gives the usual generic 80-bit collision bound and
+the mixed schedule is not independently cryptanalysed. Hiding still requires
+min-entropy in the unrevealed preimage/trit pair. Exact byte canonicality is
+enforced by the fragment, but protocol callers must still bind the path length,
+bit width, commitment, participant/round context, and terminal predicate.
+
+All trits are present at script entry and there are no hint items. The 20-trit
+representative stays below the 1,000-item combined stack limit in the strict
+local test, but composition with surrounding protocol state must be measured.
+
+See the [implementation README](../../src/commitments/README.md), the
+[commitment comparison](../comparisons/commitments.md), and catalog record
+`commitment/ternary-hash-path-integer`.

--- a/research/ternary-hash-path/README.md
+++ b/research/ternary-hash-path/README.md
@@ -1,0 +1,56 @@
+# Ternary mixed-hash integer path
+
+- **Question:** Can a canonical three-valued mixed-hash path authenticate a
+  small integer for ternary protocol state?
+- **Hypothesis:** Explicit canonical trit checks make the representation safe
+  to compose, even if its 31-bit integer cost is dominated by the four-way
+  path.
+- **Catalog record:** `commitment/ternary-hash-path-integer`
+- **Comparison objective:** Compare a 31-bit, 32-byte-preimage ternary path
+  with the existing binary and four-way paths under the fragment-only boundary.
+- **Repository commit:** record the merge commit in the PR that adds this
+  experiment.
+- **External source revisions:** `bitcoin-script-locked`, `bitcoin-scriptexec-locked`,
+  BIP 342, and FIPS 180-4 as catalog references.
+- **Interpreter and execution class:** centralized policy compiler; focused
+  correctness tests use the strict local tapscript-context executor; deployment
+  is `unclassified`.
+- **Deterministic vector:** 32 bytes of `0x42`, value `0x12345678`, 31 bits.
+
+## Reproduction
+
+```sh
+cargo test --locked ternary_hash_path --lib
+cargo test --locked --test primitive_metrics ternary_hash_path_metrics_are_current
+cargo run --locked --example ternary_hash_path_benchmark
+```
+
+## Measurement boundary
+
+The verifier and base-3 reconstruction are included. Input pushes, terminal
+predicates, transaction framing, and unrelated protocol state are excluded.
+The witness includes all 20 canonical trit items, the 32-byte preimage, and
+Bitcoin witness serialization framing. There are zero auxiliary hint items.
+
+## Results
+
+The 31-bit representative is 924 policy-produced script bytes, 63 serialized
+witness bytes, 21 witness items, and a 24-item combined local peak. It is
+larger than the four-way path for this integer objective but preserves a native
+three-valued selector. The strict tapscript executor reports
+`executed_opcodes=0` because its legacy opcode counter is unavailable in
+tapscript; the experiment therefore leaves that metric unclaimed. No raw
+private seed is part of the public fixture.
+
+## Falsification attempts
+
+Focused tests cover all codewords, integer boundaries, wrong openings, padded
+encodings, and an out-of-range trit. The local strict executor accepts the
+valid fixtures and rejects those malformed witnesses. Bitcoin Core differential
+validation and policy testing remain open.
+
+## Conclusion and knowledge updates
+
+The hypothesis survived the local correctness boundary. The implementation,
+metrics, comparison, catalog, negative result, and open problem are updated;
+the construction remains experimental and unclassified for deployment.

--- a/src/commitments/README.md
+++ b/src/commitments/README.md
@@ -1,6 +1,6 @@
 # Integer commitments
 
-This module contains three constructions that authenticate a small integer and
+This module contains four constructions that authenticate a small integer and
 return it to the surrounding Bitcoin Script. They are commitment primitives,
 not general-purpose hash functions.
 
@@ -10,10 +10,12 @@ not general-purpose hash functions.
   integer.
 - **Four-way hash path:** two bits select one of four fixed-length hash
   codewords per base-4 digit, reducing witness items and peak stack usage.
+- **Ternary hash path:** three canonical trits select three fixed-length
+  mixed-hash codewords and reconstruct a base-3 integer.
 - **Preimage length:** a SHA-256 preimage is authenticated and its byte length,
   minus a public offset, becomes the committed integer.
 
-All three are experimental. In particular, a hash-path commitment is
+All four are experimental. In particular, a hash-path commitment is
 deterministic and does not hide an opening when both its preimage and bits come
 from small enumerable spaces.
 
@@ -54,6 +56,19 @@ from small enumerable spaces.
 - The generic verifier consumes digits or retains them on the altstack; the
   integer verifier hashes and reconstructs them most-significant first in one
   pass. There is no default variant.
+
+### Ternary hash path
+
+- `bit_width`: required, with integer reconstruction limited to `1..=31`.
+  The adapter uses the smallest fixed number of base-3 trits that covers the
+  full width (`20` trits at 31 bits).
+- `preimage`: caller-chosen byte string subject to the same secrecy and
+  520-byte stack-element obligations as the binary and four-way paths.
+- `commitment`: 20 bytes. The canonical codewords are `0 -> SS`, `1 -> SR`,
+  and `2 -> RS`, leaving `RR` unused. Non-canonical and out-of-range trit
+  encodings are rejected explicitly.
+- The integer verifier hashes least-significant trits first, then reconstructs
+  the base-3 value. There is no default variant.
 
 ## Rolling composition without byte concatenation
 
@@ -132,7 +147,13 @@ the tests with the listed witness.
 | --- | ---: | ---: | ---: |
 | `verify_hash_path_to_integer(31, commitment)` | <!-- metric:hash_path_integer_31 -->520<!-- /metric:hash_path_integer_31 --> bytes | <!-- metric:hash_path_integer_witness_31 -->78<!-- /metric:hash_path_integer_witness_31 --> bytes (32-byte nonce, 31 bits) | <!-- metric:hash_path_integer_stack_31 -->34<!-- /metric:hash_path_integer_stack_31 --> |
 | `verify_four_way_hash_path_to_integer(31, commitment)` | <!-- metric:four_way_hash_path_integer_31 -->438<!-- /metric:four_way_hash_path_integer_31 --> bytes | <!-- metric:four_way_hash_path_integer_witness_31 -->61<!-- /metric:four_way_hash_path_integer_witness_31 --> bytes (32-byte nonce, 16 digits) | <!-- metric:four_way_hash_path_integer_stack_31 -->19<!-- /metric:four_way_hash_path_integer_stack_31 --> |
+| `verify_ternary_hash_path_to_integer(31, commitment)` | <!-- metric:ternary_hash_path_integer_31 -->924<!-- /metric:ternary_hash_path_integer_31 --> bytes | <!-- metric:ternary_hash_path_integer_witness_31 -->63<!-- /metric:ternary_hash_path_integer_witness_31 --> bytes (32-byte nonce, 20 trits) | <!-- metric:ternary_hash_path_integer_stack_31 -->24<!-- /metric:ternary_hash_path_integer_stack_31 --> |
 | `verify_preimage_length(commitment)` | <!-- metric:preimage_length_default -->44<!-- /metric:preimage_length_default --> bytes | <!-- metric:preimage_length_witness_min -->18<!-- /metric:preimage_length_witness_min -->–<!-- metric:preimage_length_witness_max -->524<!-- /metric:preimage_length_witness_max --> bytes (16–520-byte preimage) | <!-- metric:preimage_length_stack -->3<!-- /metric:preimage_length_stack --> |
+
+The benchmark executes the representative witness under the strict local
+tapscript-context executor. Its `opcode_count` reports `0` because that
+interpreter counter covers legacy execution and is unavailable for tapscript;
+no executed-opcode total is claimed for this fragment.
 
 ## Security
 
@@ -154,6 +175,12 @@ double-hash opcodes are compositions of the former primitives. The fixed-length
 code avoids those structural aliases but is still a non-standard construction
 without a dedicated cryptanalysis.
 
+The ternary path uses three of the four fixed two-hash codewords. Its explicit
+canonical trit checks prevent alternate byte encodings from selecting the same
+digit, but the construction remains a non-standard mixed-hash scheme without
+dedicated cryptanalysis. For ordinary 31-bit integer metrics it is expected to
+lose to the four-way path; its purpose is a native three-valued state encoding.
+
 The preimage-length construction uses SHA-256, giving generic 128-bit collision
 resistance and 256-bit preimage/second-preimage resistance. Its hiding property
 depends on unpredictable preimage bytes; length alone is not secret once the
@@ -173,6 +200,9 @@ more restrictive: its compact range proof relies on tapscript's
 consensus-enforced `MINIMALIF`. It is unsafe under legacy or P2WSH consensus
 semantics without adding explicit range checks, even though every emitted
 opcode exists there. Both measured 31-bit variants are tapscript-only.
+The ternary path performs its own exact trit checks, so it does not rely on
+`MINIMALIF`; its measured 31-bit fragment is still evaluated only in the local
+tapscript-context executor.
 Tapscript still enforces the 1,000-item combined stack limit, the 520-byte
 per-item limit, witness weight, and execution budget.
 
@@ -183,7 +213,7 @@ it with a predicate that leaves one truthy cleanstack item. See
 
 ## Witness and hints
 
-Neither construction uses arithmetic hints.
+These constructions use no arithmetic hints.
 
 For the integer hash path, witness serialization order is `bitN-1, ...,
 bit0, preimage`; the preimage is therefore on top at script entry. A false bit
@@ -198,6 +228,12 @@ helper produces minimal encodings, and the local executor's `MINIMALDATA`
 setting rejects non-minimal test witnesses. Numeric minimality is not itself a
 tapscript consensus rule, so callers must treat the digit value, rather than a
 unique byte representation, as committed.
+
+For the ternary integer path, witness order is `most_significant_trit`, ...,
+`least_significant_trit`, `preimage`. Zero is the empty vector and `1`/`2` are
+exactly `[01]`/`[02]`; padded, negative-zero, and other encodings are rejected.
+The helper produces this canonical encoding and the verifier reconstructs the
+integer in base 3.
 
 For the preimage-length construction, the witness contains the committed
 preimage as one item. The preimage is consumed and only the resulting integer
@@ -220,6 +256,9 @@ remains.
 - `verify_four_way_hash_path`: `... digitN-1 ... digit0 preimage -> ... true`.
 - `verify_four_way_hash_path_to_altstack` leaves digit `N-1` on top of the
   altstack.
+- `verify_ternary_hash_path_to_integer`: `... tritN-1 ... trit0 preimage ->
+  ... value`, with the trits restored from the altstack during reconstruction.
+- `verify_ternary_hash_path`: `... tritN-1 ... trit0 preimage -> ... true`.
 - `verify_preimage_length`: `... preimage -> ... length_minus_offset`.
 
 The hash-path construction generalizes the former fixed-width `BitHash128`

--- a/src/commitments/mod.rs
+++ b/src/commitments/mod.rs
@@ -3,6 +3,7 @@
 pub mod four_way_hash_path;
 pub mod hash_path;
 pub mod preimage_length;
+pub mod ternary_hash_path;
 
 pub use four_way_hash_path::{
     four_way_hash_path_commitment, four_way_hash_path_integer_commitment,
@@ -17,4 +18,9 @@ pub use hash_path::{
 pub use preimage_length::{
     preimage_length_commitment, verify_preimage_length, verify_preimage_length_with_offset,
     DEFAULT_PREIMAGE_LENGTH_OFFSET, MAX_PREIMAGE_LENGTH,
+};
+pub use ternary_hash_path::{
+    ternary_hash_path_commitment, ternary_hash_path_integer_commitment,
+    ternary_hash_path_integer_witness, ternary_hash_path_script, ternary_hash_path_witness,
+    verify_ternary_hash_path, verify_ternary_hash_path_to_integer,
 };

--- a/src/commitments/ternary_hash_path.rs
+++ b/src/commitments/ternary_hash_path.rs
@@ -1,0 +1,279 @@
+//! Ternary hash-path commitments using fixed-length SHA-256/RIPEMD-160 codewords.
+//!
+//! The three codewords are `0 -> SS`, `1 -> SR`, and `2 -> RS`. The unused
+//! `RR` codeword keeps every trit at exactly two hashes while leaving a
+//! canonical three-valued selector.
+
+use bitcoin::hashes::{ripemd160, sha256, Hash};
+
+use crate::support::script::{script, Script};
+
+use super::hash_path::MAX_INTEGER_BITS;
+
+/// Compute a ternary hash-path commitment for least-significant-first trits.
+pub fn ternary_hash_path_commitment(preimage: &[u8], trits: &[u8]) -> [u8; 20] {
+    let mut state = preimage.to_vec();
+    for &trit in trits {
+        assert!(trit < 3, "ternary hash-path trits must be in 0..=2");
+        state = match trit {
+            0 => sha256::Hash::hash(&sha256::Hash::hash(&state).to_byte_array())
+                .to_byte_array()
+                .to_vec(),
+            1 => ripemd160::Hash::hash(&sha256::Hash::hash(&state).to_byte_array())
+                .to_byte_array()
+                .to_vec(),
+            2 => sha256::Hash::hash(&ripemd160::Hash::hash(&state).to_byte_array())
+                .to_byte_array()
+                .to_vec(),
+            _ => unreachable!(),
+        };
+    }
+    ripemd160::Hash::hash(&state).to_byte_array()
+}
+
+/// Compute a ternary commitment to a `bit_width`-bit integer.
+pub fn ternary_hash_path_integer_commitment(
+    preimage: &[u8],
+    value: u32,
+    bit_width: usize,
+) -> [u8; 20] {
+    let trits = integer_trits(value, bit_width);
+    ternary_hash_path_commitment(preimage, &trits)
+}
+
+/// Build the canonical witness for [`verify_ternary_hash_path_to_integer`].
+///
+/// The witness order is most-significant trit first, then `preimage`; the
+/// verifier's first `OP_SWAP` activates the least-significant trit.
+pub fn ternary_hash_path_integer_witness(
+    preimage: &[u8],
+    value: u32,
+    bit_width: usize,
+) -> Vec<Vec<u8>> {
+    let trits = integer_trits(value, bit_width);
+    ternary_hash_path_witness(preimage, &trits)
+}
+
+/// Build a canonical witness for a generic ternary path.
+pub fn ternary_hash_path_witness(preimage: &[u8], trits: &[u8]) -> Vec<Vec<u8>> {
+    let mut witness = trits
+        .iter()
+        .rev()
+        .map(|&trit| {
+            assert!(trit < 3, "ternary hash-path trits must be in 0..=2");
+            match trit {
+                0 => vec![],
+                1 | 2 => vec![trit],
+                _ => unreachable!(),
+            }
+        })
+        .collect::<Vec<_>>();
+    witness.push(preimage.to_vec());
+    witness
+}
+
+fn integer_trits(value: u32, bit_width: usize) -> Vec<u8> {
+    assert_integer_width(bit_width);
+    assert!(
+        value < (1u32 << bit_width),
+        "value does not fit in bit_width"
+    );
+    let mut value = u64::from(value);
+    let mut trits = Vec::with_capacity(integer_trit_count(bit_width));
+    for _ in 0..integer_trit_count(bit_width) {
+        trits.push((value % 3) as u8);
+        value /= 3;
+    }
+    assert_eq!(value, 0);
+    trits
+}
+
+fn integer_trit_count(bit_width: usize) -> usize {
+    let limit = 1u64 << bit_width;
+    let mut capacity = 1u64;
+    let mut count = 0;
+    while capacity < limit {
+        capacity *= 3;
+        count += 1;
+    }
+    count
+}
+
+fn assert_integer_width(bit_width: usize) {
+    assert!(
+        (1..=MAX_INTEGER_BITS).contains(&bit_width),
+        "bit_width must be in 1..={MAX_INTEGER_BITS}"
+    );
+}
+
+fn certify_trit() -> Script {
+    script! {
+        OP_DUP
+        OP_0
+        OP_EQUAL
+        OP_IF
+            OP_SIZE
+            OP_0
+            OP_EQUALVERIFY
+        OP_ELSE
+            OP_DUP
+            1
+            OP_EQUAL
+            OP_IF
+            OP_ELSE
+                OP_DUP
+                2
+                OP_EQUALVERIFY
+            OP_ENDIF
+        OP_ENDIF
+    }
+}
+
+fn ternary_hash_path_script_inner(trit_count: usize, save_trits: bool) -> Script {
+    assert!(trit_count > 0, "trit_count must be non-zero");
+    script! {
+        for _ in 0..trit_count {
+            OP_SWAP
+            { certify_trit() }
+
+            if save_trits {
+                OP_DUP
+                OP_TOALTSTACK
+            }
+
+            OP_DUP
+            2
+            OP_LESSTHAN
+            OP_IF
+                OP_SWAP
+                OP_SHA256
+                OP_SWAP
+                OP_IF
+                    OP_RIPEMD160
+                OP_ELSE
+                    OP_SHA256
+                OP_ENDIF
+            OP_ELSE
+                2
+                OP_EQUALVERIFY
+                OP_RIPEMD160
+                OP_SHA256
+            OP_ENDIF
+        }
+        OP_RIPEMD160
+    }
+}
+
+/// Compute a ternary hash path from a preimage and least-significant-first trits.
+pub fn ternary_hash_path_script(trit_count: usize) -> Script {
+    ternary_hash_path_script_inner(trit_count, false)
+}
+
+/// Verify a generic ternary hash path and leave true.
+pub fn verify_ternary_hash_path(trit_count: usize, commitment: [u8; 20]) -> Script {
+    script! {
+        { ternary_hash_path_script(trit_count) }
+        { commitment.to_vec() }
+        OP_EQUALVERIFY
+        OP_1
+    }
+}
+
+/// Verify a ternary path and reconstruct its committed integer.
+pub fn verify_ternary_hash_path_to_integer(bit_width: usize, commitment: [u8; 20]) -> Script {
+    assert_integer_width(bit_width);
+    let trit_count = integer_trit_count(bit_width);
+    script! {
+        { ternary_hash_path_script_inner(trit_count, true) }
+        { commitment.to_vec() }
+        OP_EQUALVERIFY
+
+        0
+        for _ in 0..trit_count {
+            OP_FROMALTSTACK
+            OP_SWAP
+            OP_DUP
+            OP_DUP
+            OP_ADD
+            OP_ADD
+            OP_ADD
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::support::execution::execute_script_with_inputs_strict;
+
+    #[test]
+    fn verifies_all_ternary_codewords() {
+        let preimage = b"ternary nonce";
+        for trit in 0..3 {
+            let trits = [trit];
+            let commitment = ternary_hash_path_commitment(preimage, &trits);
+            let result = execute_script_with_inputs_strict(
+                verify_ternary_hash_path(1, commitment),
+                ternary_hash_path_witness(preimage, &trits),
+            );
+            assert!(result.success, "trit={trit}: {result}");
+        }
+    }
+
+    #[test]
+    fn verifies_integer_boundaries_and_values() {
+        for (value, width) in [
+            (0, 1),
+            (1, 1),
+            (2, 2),
+            (4, 3),
+            (0x55, 7),
+            (0x1234_5678, 31),
+            (u32::MAX >> 1, 31),
+        ] {
+            let preimage = [0x42; 32];
+            let commitment = ternary_hash_path_integer_commitment(&preimage, value, width);
+            let result = execute_script_with_inputs_strict(
+                script! {
+                    { verify_ternary_hash_path_to_integer(width, commitment) }
+                    { value }
+                    OP_EQUAL
+                },
+                ternary_hash_path_integer_witness(&preimage, value, width),
+            );
+            assert!(result.success, "value={value}, width={width}: {result}");
+        }
+    }
+
+    #[test]
+    fn rejects_wrong_openings_and_noncanonical_trits() {
+        let preimage = [0x11; 32];
+        let commitment = ternary_hash_path_integer_commitment(&preimage, 17, 6);
+        let wrong_value = ternary_hash_path_integer_witness(&preimage, 18, 6);
+        let result = execute_script_with_inputs_strict(
+            script! { { verify_ternary_hash_path_to_integer(6, commitment) } OP_DROP OP_1 },
+            wrong_value,
+        );
+        assert!(!result.success);
+
+        let mut noncanonical = ternary_hash_path_integer_witness(&preimage, 17, 6);
+        noncanonical[0] = vec![2, 0];
+        let result = execute_script_with_inputs_strict(
+            script! { { verify_ternary_hash_path_to_integer(6, commitment) } OP_DROP OP_1 },
+            noncanonical,
+        );
+        assert!(!result.success);
+    }
+
+    #[test]
+    fn rejects_out_of_range_generic_trits() {
+        let preimage = b"bad trit";
+        let commitment = ternary_hash_path_commitment(preimage, &[0, 1, 2]);
+        let witness = vec![vec![3], vec![], vec![], preimage.to_vec()];
+        let result = execute_script_with_inputs_strict(
+            script! { { verify_ternary_hash_path(3, commitment) } OP_DROP OP_1 },
+            witness,
+        );
+        assert!(!result.success);
+    }
+}

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -15,7 +15,9 @@ use bitcoin_lab::{
     commitments::{
         four_way_hash_path_integer_commitment, four_way_hash_path_integer_witness,
         hash_path_integer_commitment, hash_path_integer_witness, preimage_length_commitment,
+        ternary_hash_path_integer_commitment, ternary_hash_path_integer_witness,
         verify_four_way_hash_path_to_integer, verify_hash_path_to_integer, verify_preimage_length,
+        verify_ternary_hash_path_to_integer,
     },
     curves::bn254::groups::{g1::G1Affine, g2::G2Affine},
     fields::{
@@ -1849,6 +1851,11 @@ fn metrics() -> Vec<Metric> {
         four_way_hash_path_integer_commitment(&hash_path_preimage, hash_path_value, 31);
     let four_way_hash_path_witness =
         four_way_hash_path_integer_witness(&hash_path_preimage, hash_path_value, 31);
+
+    let ternary_hash_path_commitment =
+        ternary_hash_path_integer_commitment(&hash_path_preimage, hash_path_value, 31);
+    let ternary_hash_path_witness =
+        ternary_hash_path_integer_witness(&hash_path_preimage, hash_path_value, 31);
 
     let length_preimage = vec![0x24; 32];
     let length_commitment = preimage_length_commitment(&length_preimage);
@@ -3724,6 +3731,27 @@ fn metrics() -> Vec<Metric> {
         },
         Metric {
             readme: "src/commitments/README.md",
+            key: "ternary_hash_path_integer_31",
+            value: script_len(verify_ternary_hash_path_to_integer(
+                31,
+                ternary_hash_path_commitment,
+            )),
+        },
+        Metric {
+            readme: "src/commitments/README.md",
+            key: "ternary_hash_path_integer_witness_31",
+            value: witness_size(&ternary_hash_path_witness),
+        },
+        Metric {
+            readme: "src/commitments/README.md",
+            key: "ternary_hash_path_integer_stack_31",
+            value: max_stack_items(
+                verify_ternary_hash_path_to_integer(31, ternary_hash_path_commitment),
+                ternary_hash_path_witness,
+            ),
+        },
+        Metric {
+            readme: "src/commitments/README.md",
             key: "preimage_length_default",
             value: script_len(verify_preimage_length(length_commitment)),
         },
@@ -4018,6 +4046,31 @@ fn winternitz_metrics_are_current() {
             .chain(winternitz20_composition_metrics())
             .collect(),
     );
+}
+
+#[test]
+fn ternary_hash_path_metrics_are_current() {
+    let preimage = vec![0x42; 32];
+    let value = 0x1234_5678;
+    let commitment = ternary_hash_path_integer_commitment(&preimage, value, 31);
+    let witness = ternary_hash_path_integer_witness(&preimage, value, 31);
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/commitments/README.md",
+            key: "ternary_hash_path_integer_31",
+            value: script_len(verify_ternary_hash_path_to_integer(31, commitment)),
+        },
+        Metric {
+            readme: "src/commitments/README.md",
+            key: "ternary_hash_path_integer_witness_31",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/commitments/README.md",
+            key: "ternary_hash_path_integer_stack_31",
+            value: max_stack_items(verify_ternary_hash_path_to_integer(31, commitment), witness),
+        },
+    ]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a canonical ternary mixed-hash commitment path with `0 -> SS`, `1 -> SR`, and `2 -> RS`
- reconstruct 1–31-bit integers with explicit canonical trit validation
- add focused correctness tests, metrics, benchmark, catalog, comparison, research, negative-result, and open-problem updates

## Representative result
For a 32-byte preimage and 31-bit value: 924 policy-produced script bytes, 63 serialized witness bytes, 21 witness items, and a 24-item peak. This is intentionally retained as a native three-valued state representation, not as an integer byte-efficiency improvement over the four-way path.

## Validation
- `cargo fmt --all -- --check`
- `python3 tools/kb.py validate`
- `cargo test --locked ternary_hash_path --lib`
- `cargo test --locked --test primitive_metrics ternary_hash_path_metrics_are_current`
- `cargo test --locked --example ternary_hash_path_benchmark`
- `cargo run --locked --example ternary_hash_path_benchmark`

The full repository-wide suite was not run; field-arithmetic tests remain outside this focused validation.
