### PR TITLE
feat(hashes): add SHAKE256 output prefixes

### DIFF
--- a/examples/shake256_prefix_benchmark.rs
+++ b/examples/shake256_prefix_benchmark.rs
@@ -1,0 +1,31 @@
+use bitcoin::consensus::encode::serialize;
+use bitcoin::Witness;
+use bitcoin_lab::hashes::shake256::shake256_prefix;
+use bitcoin_lab::support::execution::execute_script_with_inputs_strict;
+use bitcoin_lab::support::script::{script, ScriptCompilation};
+
+fn main() {
+    let witness = vec![vec![0x42]; 32];
+    let prefix = shake256_prefix(32, 32);
+    let measured = script! {
+        { prefix.clone() }
+        for _ in 0..16 { OP_2DROP }
+        OP_TRUE
+    };
+    let execution = execute_script_with_inputs_strict(measured, witness.clone());
+    assert!(execution.success, "benchmark fixture failed: {execution}");
+
+    println!("primitive=shake256_prefix");
+    println!("message_bytes=32");
+    println!("output_bytes=32");
+    println!("script_bytes={}", prefix.compile_with_policy().len());
+    println!(
+        "witness_bytes={}",
+        serialize(&Witness::from_slice(&witness)).len()
+    );
+    println!("witness_items={}", witness.len());
+    println!("hint_items=0");
+    println!("stack_peak={}", execution.stats.max_nb_stack_items);
+    println!("executed_opcodes={}", execution.stats.opcode_count);
+    println!("execution_class=unclassified");
+}

--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "as_of": "2026-09-01",
+  "as_of": "2026-09-11",
   "cost_model": "knowledge/cost-model.md",
   "records": [
     {
@@ -2163,6 +2163,73 @@
         "OP-001",
         "OP-003",
         "OP-013"
+      ]
+    },
+    {
+      "id": "hash/shake256-prefix",
+      "name": "SHAKE256 byte-lane output prefix",
+      "class": "hash/xof",
+      "summary": "FIPS 202 SHAKE256 with a generation-time output prefix that avoids materializing the unused XOF suffix.",
+      "status": "experimental",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/shake256-prefix.md",
+      "implementation": "src/hashes/shake256/mod.rs",
+      "documentation": "src/hashes/shake256/README.md",
+      "tests": [
+        "hashes::shake256::tests::hashes_prefixes_to_the_standard_output",
+        "hashes::shake256::tests::small_prefix_stays_below_the_stack_limit",
+        "hashes::shake256::tests::rejects_invalid_prefix_lengths",
+        "primitive_metrics::shake256_prefix_metrics_are_current",
+        "examples/shake256_prefix_benchmark.rs"
+      ],
+      "references": [
+        "fips-202",
+        "bitcoin-scriptexec-locked"
+      ],
+      "techniques": [
+        "sponge",
+        "digit-arithmetic",
+        "lookup-table"
+      ],
+      "security": "Security is inherited from SHAKE256 if the byte-lane permutation, domain suffix, and padding are correct; callers must bind the generated output length and any consumer predicate.",
+      "stack_contract": "Consumes one item per input byte and leaves `output_len` byte items with the first prefix byte on top.",
+      "configurations": [
+        {
+          "id": "message-32-output-32",
+          "label": "32-byte input and 32-byte prefix",
+          "parameters": {
+            "message_bytes": 32,
+            "output_bytes": 32
+          },
+          "includes": "fragment-with-memory: generated sponge, lookup-table setup/cleanup, and prefix squeeze; excludes message pushes, output comparison, terminal predicate, and transaction framing",
+          "script_bytes": 2000127,
+          "witness_bytes": 65,
+          "witness_bytes_max": 65,
+          "max_stack_items": 813,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 2000127,
+          "metric_keys": [
+            "shake256_prefix_32_32",
+            "shake256_prefix_witness_32",
+            "shake256_prefix_stack_32_32"
+          ]
+        }
+      ],
+      "limitations": [
+        "Only the representative 32-byte prefix has a strict local stack measurement",
+        "The 2,000,127-byte fragment remains impractical for ordinary script-size and relay-policy limits",
+        "Executed-opcode counter is unavailable in the local tapscript interpreter",
+        "Bitcoin Core consensus and policy validation not performed"
+      ],
+      "open_problems": [
+        "OP-001",
+        "OP-002",
+        "OP-003",
+        "OP-005"
       ]
     },
     {

--- a/knowledge/comparisons/hashes.md
+++ b/knowledge/comparisons/hashes.md
@@ -11,6 +11,7 @@ Measured fragments exclude input pushes and output comparison.
 | SHA-256 u4 | 32-byte input | 332,942 | differentially-validated | Large research fragment |
 | SHA-256 u32 | 32-byte input | 512,428 | differentially-validated | Larger than local u4 variant |
 | SHAKE256 byte | 32-byte input, 1,024-byte output | 15,927,814 | locally-reproduced | Raw output exceeds 1,000 items |
+| SHAKE256 byte prefix | 32-byte input, 32-byte output | 2,000,127 | locally-reproduced | Strict stack-compatible locally; still a 2 MB fragment |
 
 BLAKE3's 64-byte row is not directly comparable with the 32-byte hash rows
 without fixing message length and full semantics. The short direct-u4 row does
@@ -27,3 +28,9 @@ Every nontrivial row in the table exceeds the repository optimizer's 32 KiB
 input cutoff and is unoptimized by those upstream passes. BLAKE3 still applies
 its separately documented pinned peephole pass before the repository
 compilation policy.
+
+The prefix row is a distinct cost point, not a claim that the full XOF is
+deployable: it only materializes the requested output blocks. Its 813-item
+strict local peak stays below the 1,000-item limit for the representative
+32-byte prefix, but Bitcoin Core and relay policy have not been run and the
+2,000,127-byte fragment remains impractical as a standard script.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -6,7 +6,7 @@ reproducible constructions. The local Rust library is one source of evidence;
 it is not the boundary of the atlas.
 
 The catalog is explicitly time-scoped. Its current review date is
-**2026-09-04**. A record's `as_of` field says when its claims were last checked.
+**2026-09-11**. A record's `as_of` field says when its claims were last checked.
 Missing records are unknown coverage, not proof of nonexistence.
 
 ## How to answer a research question

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,12 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+## NR-044: Full SHAKE256 output remains non-composable; prefixing only fixes the stack boundary
+
+The fixed 1,024-byte SHAKE256 output materializes 1,024 stack items and has a
+1,709-item local peak, so it remains consensus-incompatible. A parameterized
+32-byte prefix reduces the peak to 813 and preserves the FIPS 202 output, but
+still generates a 2,000,127-byte fragment. The prefix is therefore a useful
+stack-boundary experiment, not a deployable replacement or a complete
+incremental squeeze protocol. Larger prefixes require their own strict
+measurement because the live state, lookup table, and output all coexist.

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -106,6 +106,12 @@ Avoid the 1,024-item raw-output failure. **Complete when:** a parameterized or
 incremental squeeze passes strict stack checks and is differentially validated
 against FIPS 202 for boundary message/output lengths.
 
+Progress: `shake256_prefix` now parameterizes the output length. Prefixes of
+1, 32, 135, 136, 137, and 256 bytes match the independent reference, and the
+32-byte prefix peaks at 813 items under the strict local executor. The
+representative fragment is still 2,000,127 bytes, and Bitcoin Core/policy
+validation plus an incremental consumer remain open.
+
 ## OP-006 — BN254 hinted-operation inventory
 
 Catalog full costs and binding equations for every hint-producing field and

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -36,6 +36,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [BLAKE3 sparse direct-u4 short inputs](blake3-short-u4.md)
 - [BLAKE3 Ed25519-style challenge transcripts](blake3-ed25519-challenge.md)
 - [SHAKE256 over byte lanes](shake256-byte.md)
+- [SHAKE256 byte-lane output prefixes](shake256-prefix.md)
 - [AES-128 over u4 digits](aes128-u4.md)
 - [PRINCEv2 over u4 digits](princev2-u4.md)
 

--- a/knowledge/primitives/shake256-prefix.md
+++ b/knowledge/primitives/shake256-prefix.md
@@ -1,0 +1,55 @@
+# SHAKE256 byte-lane output prefixes
+
+The prefix variant of the repository's byte-oriented SHAKE256 implementation
+returns only the requested leading output bytes instead of materializing the
+fixed 1,024-byte XOF result.
+
+## Research question
+
+Can output-length specialization turn the existing consensus-incompatible
+1,024-item SHAKE256 experiment into a stack-compatible small-output primitive
+without changing its FIPS 202 byte convention or Keccak implementation?
+
+The hypothesis is intentionally narrow: a prefix of at most a few dozen bytes
+should stay below the 1,000-item combined stack limit, while preserving the
+same output bytes as the 1,024-byte reference.
+
+## Construction and boundary
+
+`shake256_prefix(message_bytes, output_bytes)` uses the existing byte-lane
+absorption and Keccak-f[1600] code, then squeezes only the number of rate blocks
+needed for the requested prefix. `output_bytes` is fixed at generation time and
+must be in `1..=1024`; the input remains fixed at `0..=511` bytes. The fragment
+consumes one byte item per message byte and leaves the first prefix byte on top.
+
+The representative boundary includes the generated sponge, lookup-table setup
+and cleanup, and output restoration. It excludes message pushes, output
+comparison, terminal predicates, and transaction framing. The witness is 32
+one-byte message items; there are zero hint items.
+
+## Evidence and metrics
+
+Evidence is `locally-reproduced`. Prefixes of 1, 32, 135, 136, 137, and 256
+bytes match an independent 1,024-byte SHAKE256 reference, including the rate
+boundary. A 32-byte prefix passes the strict local combined-stack check.
+
+| Configuration | Script bytes | Witness bytes | Peak items |
+| --- | ---: | ---: | ---: |
+| 32-byte input, 32-byte prefix | 2,000,127 | 65 | 813 |
+
+The local tapscript interpreter reports `opcode_count=0` for this execution
+because its legacy opcode counter is unavailable in tapscript; executed-opcode
+count is therefore left unclaimed. Deployment remains `unclassified` pending
+Bitcoin Core consensus and policy validation.
+
+## Limitations
+
+The prefix avoids the raw output's stack overflow, but the 2 MB representative
+fragment is still unsuitable for ordinary script-size and relay-policy limits.
+Only small prefixes have been strict-executed; callers must measure larger
+prefixes because the live Keccak state, lookup table, and altstack output all
+count toward the 1,000-item limit.
+
+See the [implementation README](../../src/hashes/shake256/README.md), the
+[hash comparison](../comparisons/hashes.md), and research record
+`research/shake256-prefix/README.md`.

--- a/research/shake256-prefix/README.md
+++ b/research/shake256-prefix/README.md
@@ -1,0 +1,44 @@
+# SHAKE256 output-prefix experiment
+
+- **Question:** Can a generation-time output prefix make the byte-lane SHAKE256
+  construction stack-compatible for small outputs?
+- **Hypothesis:** Prefixes that fit in the remaining stack headroom preserve the
+  FIPS 202 output while avoiding the 1,024-item raw-output failure.
+- **Comparison objective:** Compare the 32-byte prefix with the existing
+  1,024-byte SHAKE256 construction under the `fragment-with-memory:` boundary.
+- **Threat model:** Message byte items and output consumers are hostile; the
+  primitive must preserve byte-lane semantics and callers must bind output
+  length and any terminal digest predicate.
+- **Execution class:** strict local tapscript-context execution for the 32-byte
+  prefix; deployment remains `unclassified`; the full output remains
+  `research-unlimited` and consensus-incompatible.
+- **Hard constraints:** input length `<512`, output length `1..=1024`, 520-byte
+  item limit, and 1,000 combined main/alt-stack items.
+- **Deterministic vector:** 32 message bytes of `0x42`, 32 output bytes.
+
+## Reproduction
+
+```sh
+cargo test --locked hashes::shake256::tests::hashes_prefixes_to_the_standard_output --lib
+cargo test --locked hashes::shake256::tests::small_prefix_stays_below_the_stack_limit --lib
+cargo test --locked --test primitive_metrics shake256_prefix_metrics_are_current
+cargo run --locked --example shake256_prefix_benchmark
+```
+
+## Result
+
+The 32-byte prefix measures 2,000,127 generated script bytes, 65 serialized
+witness bytes, 32 witness items, zero hints, and an 813-item strict peak. The
+full 1,024-byte output remains 15,927,814 bytes and exceeds the combined stack
+limit. Prefix correctness matches the independent reference across lengths
+that include the 136-byte sponge-rate boundary.
+
+The local tapscript opcode counter reports zero because it only counts legacy
+execution; no executed-opcode total is inferred from static instructions.
+
+## Falsification attempts
+
+The focused tests cover empty and short reference behavior through the existing
+1,024-byte vectors, prefix lengths below, at, and above one rate block, invalid
+output lengths, and strict stack execution with output cleanup. Bitcoin Core
+differential validation and relay-policy testing remain open.

--- a/src/hashes/shake256/README.md
+++ b/src/hashes/shake256/README.md
@@ -1,15 +1,15 @@
 # SHAKE256
 
 This module implements the FIPS 202 SHAKE256 extendable-output function in
-Bitcoin Script. `shake256(num_bytes)` consumes a fixed-length byte-oriented
-message and produces exactly 1024 byte-valued stack items, with the first
-output byte on top.
+Bitcoin Script. `shake256(num_bytes)` preserves the original 1,024-byte output;
+`shake256_prefix(num_bytes, output_len)` produces a fixed-length prefix without
+materializing the unused suffix.
 
 ## Parameters
 
 - Message length: 0 through 511 bytes, fixed when the script is generated; no
   default.
-- Output length: 1024 bytes, fixed; there is no output-length parameter.
+- Output length: `1..=1024` bytes, fixed at script generation time.
 - Input: one stack item per byte, first message byte on top.
 - Output: 1024 byte-valued stack items, first SHAKE byte on top.
 - Sponge rate: 136 bytes; capacity: 512 bits.
@@ -32,12 +32,14 @@ predicate after the measured peak so execution can finish successfully.
 | Configuration | Locking script | Unlocking witness | Maximum stack items |
 | --- | ---: | ---: | ---: |
 | 32-byte input, 1024-byte output | <!-- metric:shake256_32_1024 -->15927814<!-- /metric:shake256_32_1024 --> bytes | <!-- metric:shake256_witness_32 -->65<!-- /metric:shake256_witness_32 --> bytes | <!-- metric:shake256_stack_32_1024 -->1709<!-- /metric:shake256_stack_32_1024 --> |
+| 32-byte input, 32-byte prefix | <!-- metric:shake256_prefix_32_32 -->2000127<!-- /metric:shake256_prefix_32_32 --> bytes | <!-- metric:shake256_prefix_witness_32 -->65<!-- /metric:shake256_prefix_witness_32 --> bytes | <!-- metric:shake256_prefix_stack_32_32 -->813<!-- /metric:shake256_prefix_stack_32_32 --> |
 
 This fragment exceeds the repository optimizer's 32 KiB input cutoff and is
 reported unoptimized.
 
-The large script reflects eight Keccak-f[1600] permutations for the fixed
-output length, in addition to message absorption.
+The full-output script reflects eight Keccak-f[1600] permutations for the
+fixed output length, in addition to message absorption. A prefix uses only the
+permutations needed to cover its requested output blocks.
 
 ## Security
 
@@ -49,13 +51,11 @@ terminal output predicate required by their protocol.
 
 ## Script compatibility and standardness
 
-The raw output contains 1024 stack items, exceeding Bitcoin's consensus limit
-of 1,000 combined main- and alt-stack items. Consequently the standalone
-primitive must be evaluated with
-`support::execution::execute_script_without_stack_limit`. A
-different, specialized construction would have to consume squeeze blocks
-incrementally. This function is not directly usable as a consensus-valid
-tapscript in its raw-output form.
+The raw 1,024-byte output contains 1,024 stack items and exceeds Bitcoin's
+consensus limit of 1,000 combined main- and alt-stack items. The prefix form
+avoids this failure for small outputs; the representative 32-byte prefix is
+strictly executed below the limit. Larger prefixes still require a measured
+stack check after accounting for the live state and lookup table.
 
 The implementation does not rely on disabled opcodes or transaction context,
 but the output shape makes the standalone primitive non-standard and
@@ -76,20 +76,19 @@ non-byte witness values before using them in lookup-table operations.
 ## Stack contract
 
 `shake256(num_bytes)` consumes exactly `num_bytes` main-stack items and leaves
-exactly 1024 output items with byte zero on top. Its lookup table and 200-byte
-Keccak state are removed. The primitive uses the altstack while reversing the
-message and accumulating squeeze blocks, and restores it to its starting depth
-before returning the result.
+1,024 output items with byte zero on top. `shake256_prefix(num_bytes,
+output_len)` leaves exactly `output_len` items. Both variants remove their
+lookup table and 200-byte Keccak state and restore the altstack to its starting
+depth.
 
 The fragment does not append an output comparison, clean-stack check, or final
 truthy predicate.
 
 ## Operational notes
 
-Tests differentially validate all 1024 output bytes for empty input, `abc`, and
-an exact 136-byte rate block against an independent u64 sponge implementation.
-Unit tests also cover every Keccak rotation offset, lane logic, and the
-unsupported-length boundary. These executions use `bitcoin-scriptexec` in a
-tapscript context with stack-limit enforcement disabled, so the execution
-class is `research-unlimited`; the raw construction's deployment class is
-`consensus-incompatible`.
+Tests differentially validate all 1,024 output bytes for empty input, `abc`,
+and an exact 136-byte rate block, plus prefix lengths crossing the 136-byte
+rate boundary. A 32-byte prefix also passes the strict combined-stack check.
+These executions use `bitcoin-scriptexec` in a tapscript context; the full
+output remains `research-unlimited` and `consensus-incompatible`, while the
+small prefix has `unclassified` deployment evidence pending Core validation.

--- a/src/hashes/shake256/mod.rs
+++ b/src/hashes/shake256/mod.rs
@@ -64,10 +64,21 @@ const ROUND_CONSTANTS: [u64; 24] = [
 /// consensus-compatible construction would need a specialized variant that
 /// consumes squeeze blocks incrementally.
 pub fn shake256(num_bytes: usize) -> Script {
+    shake256_prefix(num_bytes, OUTPUT_LEN)
+}
+
+/// Hashes `num_bytes` byte-valued stack items with SHAKE256 and returns a
+/// fixed-length prefix of the XOF output.
+///
+/// `output_len` must be in `1..=OUTPUT_LEN`. Short prefixes avoid materializing
+/// the full 1,024-byte output and can fit the combined stack limit for small
+/// output lengths. The first output byte is left on top of the stack.
+pub fn shake256_prefix(num_bytes: usize, output_len: usize) -> Script {
     assert!(
         num_bytes < 512,
         "This SHAKE256 implementation supports messages shorter than 512 bytes"
     );
+    assert!((1..=OUTPUT_LEN).contains(&output_len));
 
     let block_count = num_bytes / RATE_BYTES + 1;
 
@@ -86,7 +97,7 @@ pub fn shake256(num_bytes: usize) -> Script {
             { keccak_f1600() }
         }
 
-        { squeeze_1024() }
+        { squeeze(output_len) }
     }
 }
 
@@ -411,21 +422,21 @@ fn chi() -> Script {
     }
 }
 
-fn squeeze_1024() -> Script {
+fn squeeze(output_len: usize) -> Script {
     script! {
-        for block in 0..OUTPUT_LEN.div_ceil(RATE_BYTES) {
+        for block in 0..output_len.div_ceil(RATE_BYTES) {
             // Copy in reverse so the first byte of this chunk is on top.
-            for _ in 0..(OUTPUT_LEN - block * RATE_BYTES).min(RATE_BYTES) {
-                { (OUTPUT_LEN - block * RATE_BYTES).min(RATE_BYTES) - 1 }
+            for _ in 0..(output_len - block * RATE_BYTES).min(RATE_BYTES) {
+                { (output_len - block * RATE_BYTES).min(RATE_BYTES) - 1 }
                 OP_PICK
             }
-            for _ in 0..(OUTPUT_LEN - block * RATE_BYTES).min(RATE_BYTES) {
+            for _ in 0..(output_len - block * RATE_BYTES).min(RATE_BYTES) {
                 OP_TOALTSTACK
             }
 
             if block * RATE_BYTES
-                + (OUTPUT_LEN - block * RATE_BYTES).min(RATE_BYTES)
-                < OUTPUT_LEN
+                + (output_len - block * RATE_BYTES).min(RATE_BYTES)
+                < output_len
             {
                 { keccak_f1600() }
             }
@@ -436,7 +447,7 @@ fn squeeze_1024() -> Script {
         }
         { u8_drop_xor_table() }
 
-        for _ in 0..OUTPUT_LEN {
+        for _ in 0..output_len {
             OP_FROMALTSTACK
         }
     }
@@ -447,7 +458,9 @@ mod tests {
     use super::*;
     use crate::{
         arithmetic::u32::xor::u8_push_xor_table,
-        support::execution::execute_script_without_stack_limit,
+        support::execution::{
+            execute_script_with_inputs_strict, execute_script_without_stack_limit,
+        },
     };
 
     fn push_message(message: &[u8]) -> Script {
@@ -602,5 +615,51 @@ mod tests {
     #[test]
     fn rejects_unsupported_message_length() {
         assert!(std::panic::catch_unwind(|| shake256(512)).is_err());
+    }
+
+    #[test]
+    fn hashes_prefixes_to_the_standard_output() {
+        let message = b"prefix fixture";
+        let expected = reference_shake256(message);
+        for output_len in [1, 32, 135, 136, 137, 256] {
+            let result = execute_script_without_stack_limit(script! {
+                { push_message(message) }
+                { shake256_prefix(message.len(), output_len) }
+            });
+            assert!(
+                result.error.is_none(),
+                "output length {output_len}: {result}"
+            );
+            assert_eq!(result.final_stack.len(), output_len);
+            for (index, expected_byte) in expected[..output_len].iter().enumerate() {
+                assert_eq!(
+                    result.final_stack.get(output_len - 1 - index),
+                    scriptnum_byte(*expected_byte),
+                    "output byte {index} at length {output_len}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn small_prefix_stays_below_the_stack_limit() {
+        let message = b"strict prefix";
+        let result = execute_script_with_inputs_strict(
+            script! {
+                { push_message(message) }
+                { shake256_prefix(message.len(), 32) }
+                for _ in 0..32 { OP_DROP }
+                OP_TRUE
+            },
+            vec![],
+        );
+        assert!(result.success, "{result}");
+        assert!(result.stats.max_nb_stack_items <= 1_000);
+    }
+
+    #[test]
+    fn rejects_invalid_prefix_lengths() {
+        assert!(std::panic::catch_unwind(|| shake256_prefix(0, 0)).is_err());
+        assert!(std::panic::catch_unwind(|| shake256_prefix(0, OUTPUT_LEN + 1)).is_err());
     }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4030,6 +4030,36 @@ fn winternitz20_metrics_are_current() {
     check_readme_metrics(winternitz20_metrics());
 }
 
+#[test]
+fn shake256_prefix_metrics_are_current() {
+    let prefix = shake256::shake256_prefix(32, 32);
+    let witness = vec![vec![0x42]; 32];
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/hashes/shake256/README.md",
+            key: "shake256_prefix_32_32",
+            value: script_len(prefix.clone()),
+        },
+        Metric {
+            readme: "src/hashes/shake256/README.md",
+            key: "shake256_prefix_witness_32",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/hashes/shake256/README.md",
+            key: "shake256_prefix_stack_32_32",
+            value: max_stack_items_strict(
+                script! {
+                    { prefix }
+                    for _ in 0..16 { OP_2DROP }
+                    OP_TRUE
+                },
+                witness,
+            ),
+        },
+    ]);
+}
+
 /// Check or intentionally refresh only the PRINCEv2 metric markers, without
 /// generating scripts for the full-repository metric suite.
 #[test]


### PR DESCRIPTION
## Summary
- add `shake256_prefix(num_bytes, output_len)` while preserving the existing 1,024-byte API
- validate prefixes against an independent SHAKE256 reference across the 136-byte rate boundary
- add strict-stack coverage, focused metrics, benchmark output, catalog/comparison/research updates, and the full-output negative result

## Representative result
For a 32-byte input and 32-byte prefix: 2,000,127 generated script bytes, 65 serialized witness bytes, 32 witness items, zero hints, and an 813-item strict local peak. The original 1,024-byte output remains consensus-incompatible at a 1,709-item peak.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked shake256 --lib`
- `cargo test --locked --test primitive_metrics shake256_prefix_metrics_are_current`
- `cargo run --locked --example shake256_prefix_benchmark`
- `python3 tools/kb.py validate`
- `git diff --check`

The full repository-wide suite was not run; field-arithmetic tests remain outside this focused validation.
