### PR TITLE
feat(introspection): reproduce Binohash legacy core

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1674,6 +1674,67 @@
       ]
     },
     {
+      "id": "introspection/binohash-legacy-core",
+      "name": "Binohash legacy core",
+      "class": "introspection/transaction",
+      "summary": "Reproduces opcode-boundary FindAndDelete and subset-dependent legacy sighash mutation for Binohash-style transaction digests.",
+      "status": "experimental",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/binohash-legacy-core.md",
+      "implementation": "src/introspection/binohash.rs",
+      "documentation": "src/introspection/README.md",
+      "tests": [
+        "introspection::binohash::tests::deletes_only_opcode_aligned_signature_pushes",
+        "introspection::binohash::tests::subset_selection_changes_legacy_digest",
+        "introspection::binohash::tests::reproduces_legacy_single_bug_digest",
+        "introspection::binohash::tests::rejects_invalid_selection_and_input"
+      ],
+      "references": [
+        "binohash-paper",
+        "bitcoin-core-interpreter",
+        "rust-bitcoin-0.32.102"
+      ],
+      "techniques": [
+        "hash-chain"
+      ],
+      "security": "This record covers deterministic legacy mechanics only; Binohash collision resistance, grinding work, ECDSA validity, and downstream Script authentication remain unproven.",
+      "stack_contract": "Host API: transaction, legacy scriptCode, candidate signature vectors, and selected indices -> 32-byte legacy sighash.",
+      "configurations": [
+        {
+          "id": "deterministic-core",
+          "label": "FindAndDelete plus legacy sighash core",
+          "parameters": {
+            "candidate_signatures": 3,
+            "selected_signatures": 1,
+            "hash_type": 1
+          },
+          "includes": "complete-transaction: host-side deterministic digest only: opcode-boundary signature deletion and rust-bitcoin legacy sighash; excludes ECDSA grinding, complete transaction execution, Script consumer, and transaction weight",
+          "script_bytes": null,
+          "witness_bytes": null,
+          "witness_bytes_max": null,
+          "max_stack_items": null,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": null,
+          "per_use_script_bytes": null,
+          "metric_keys": []
+        }
+      ],
+      "limitations": [
+        "Host-side legacy model, not a locking-script fragment",
+        "Full two-round Binohash grinding and ECDSA signature validity are not implemented",
+        "No complete transaction has been compared against a pinned Bitcoin Core regtest",
+        "No script, witness, stack, or validation-weight metric applies to this host-only boundary"
+      ],
+      "open_problems": [
+        "OP-002",
+        "OP-003",
+        "OP-011"
+      ]
+    },
+    {
       "id": "introspection/binohash",
       "name": "Binohash transaction digest",
       "class": "introspection/transaction",
@@ -1681,7 +1742,7 @@
       "status": "literature-only",
       "evidence": "reported",
       "execution": "unclassified",
-      "as_of": "2026-09-01",
+      "as_of": "2026-09-11",
       "knowledge_page": "knowledge/primitives/binohash.md",
       "implementation": null,
       "documentation": null,
@@ -1718,7 +1779,7 @@
         }
       ],
       "limitations": [
-        "No local implementation",
+        "The deterministic legacy core is reproduced separately; the full protocol remains unimplemented",
         "Relies on legacy signature semantics",
         "Grinding economics are reported, not reproduced"
       ],

--- a/knowledge/comparisons/index.md
+++ b/knowledge/comparisons/index.md
@@ -7,6 +7,7 @@ They summarize the current catalog rather than claiming global completeness.
 - [Lookup strategies](lookup-strategies.md)
 - [Hash constructions](hashes.md)
 - [Integer commitments](commitments.md)
+- [Transaction introspection](introspection.md)
 - [Signature verification and one-time authentication](signatures.md)
 - [Block ciphers](ciphers.md)
 - [BN254 layers](bn254.md)

--- a/knowledge/comparisons/introspection.md
+++ b/knowledge/comparisons/introspection.md
@@ -1,0 +1,14 @@
+# Transaction introspection
+
+These rows separate the reported full Binohash protocol from the locally
+reproduced deterministic legacy mechanics. Neither row is a deployability
+claim.
+
+| Construction | Boundary | Evidence | Execution | Main limitation |
+| --- | --- | --- | --- | --- |
+| Binohash transaction digest | Full two-round signature grinding, transaction mutation, and Script extraction | reported | unclassified | No complete local reproduction or Core regtest |
+| Binohash legacy core | Opcode-boundary `FindAndDelete` plus legacy sighash | locally-reproduced | unclassified | No grinding, complete spend, or Script consumer |
+
+The host-side core has no script, witness, stack, or validation-weight metric:
+those quantities begin at the complete legacy transaction and Script boundary,
+which remains [OP-011](../open-problems.md#op-011--reproduce-binohash).

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,12 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+
+## NR-045: Binohash legacy core does not establish the full protocol
+
+The local helper reproduces opcode-boundary `FindAndDelete`, subset-dependent
+legacy sighashes, and the historical `SIGHASH_SINGLE` constant. That boundary
+does not prove Binohash's two-round collision resistance, grinding work,
+signature validity, complete legacy transaction execution, or Script
+authentication. Those require a pinned Bitcoin Core regtest and remain under
+OP-011.

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -246,6 +246,13 @@ linked, and the catalog-wide `as_of` date is advanced.
 
 ## OP-011 — Reproduce Binohash
 
+The deterministic core is now locally reproduced: selected serialized
+signature pushes are removed at opcode boundaries before rust-bitcoin's legacy
+sighash, including the out-of-range `SIGHASH_SINGLE` constant. The full
+protocol remains open because grinding, valid ECDSA signatures, transaction
+mutation boundaries, Script extraction, and pinned Core regtest behavior are
+not yet reproduced.
+
 Implement the specified legacy signature-grinding construction and validate it
 against a pinned Bitcoin Core regtest. **Complete when:** extraction correctness,
 collision/work parameters, full transaction costs, mutation boundaries, and

--- a/knowledge/primitives/binohash-legacy-core.md
+++ b/knowledge/primitives/binohash-legacy-core.md
@@ -1,0 +1,44 @@
+# Binohash legacy core
+
+This contribution reproduces the deterministic core of a Binohash-style
+transaction digest: legacy `FindAndDelete` removes selected serialized
+signature pushes from `scriptCode`, and the resulting script is passed to the
+legacy signature-hash algorithm.
+
+## Scope
+
+The helper accepts a transaction, input index, raw `scriptCode`, candidate
+dummy-signature byte vectors, selected candidate indices, and a raw legacy
+sighash type. It returns the 32-byte legacy digest. Deletion is performed only
+at opcode boundaries, matching the legacy signature-hash construction model.
+
+The implementation deliberately stops before the probabilistic parts of the
+published Binohash protocol: it does not grind ECDSA signatures, prove the
+two-round collision/work bound, execute a complete legacy `OP_CHECKMULTISIG`
+spend, or expose transaction fields to a Script consumer.
+
+## Evidence
+
+Evidence is `locally-reproduced` for the deterministic core. Focused tests
+cover opcode-boundary deletion versus embedded bytes, subset-dependent digest
+changes, invalid selection/input errors, and the out-of-range-input
+`SIGHASH_SINGLE` digest constant. The external
+[`binohash-experiments`](https://github.com/aaron-recompile/binohash-experiments)
+suite also passes its eight covered Python tests with `PYTHONPATH=src` and
+`python-bitcoinlib`.
+
+The execution class is `unclassified`: the helper uses rust-bitcoin's legacy
+sighash serializer, but no complete transaction has been compared against a
+pinned Bitcoin Core regtest from this repository.
+
+## Security and limitations
+
+This is not a cryptographic security claim for Binohash. FindAndDelete and
+legacy sighash behavior are necessary mechanics, not sufficient evidence for
+the paper's collision-resistance or honest-work bounds. The candidate set,
+selection rule, transaction template, ECDSA signature validity, and downstream
+Script authentication all remain protocol obligations.
+
+See the [implementation README](../../src/introspection/README.md), the
+[transaction-introspection protocol page](../protocols/transaction-introspection.md),
+and `OP-011`.

--- a/knowledge/primitives/binohash.md
+++ b/knowledge/primitives/binohash.md
@@ -6,8 +6,9 @@ transaction-dependent digest that Bitcoin Script can extract and authenticate.
 
 - **Position:** external state-of-the-art transaction introspection construction
   that requires no consensus change, according to its primary source.
-- **Evidence:** reported and inspected at the paper/discussion level; no local
-  implementation or reproduction is present.
+- **Evidence:** the full protocol is reported and inspected at the
+  paper/discussion level; the deterministic legacy core is now
+  [locally reproduced](binohash-legacy-core.md).
 - **Reported profile:** the paper proposes a two-round nonce extraction design
   with tunable work/collision parameters and a Lamport-signable output.
 - **Execution context:** relies on legacy signature semantics, not the local

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -24,7 +24,11 @@ the source. Read a page together with its comparison page and evidence record.
 - [Mixed-hash path commitment](hash-path-integer.md)
 - [Four-way mixed-hash integer path](four-way-hash-path-integer.md)
 - [Preimage-length integer](preimage-length.md)
+
+## Introspection
+
 - [Binohash transaction digest](binohash.md)
+- [Binohash legacy core](binohash-legacy-core.md)
 
 ## Hashes and ciphers
 

--- a/knowledge/protocols/transaction-introspection.md
+++ b/knowledge/protocols/transaction-introspection.md
@@ -13,8 +13,11 @@ Transaction mutations and legacy sighash
 └── Lamport authentication into a later verification protocol
 ```
 
-The current atlas has no local implementation. Do not model Binohash with the
-default tapscript executor: its legacy signature context and transaction
-template are essential semantics. Reproduction requires a pinned Bitcoin Core
-regtest, exact grinding parameters, mutation constraints, and full transaction
-costs. See `introspection/binohash` and `OP-011`.
+The repository now has a narrow host-side [legacy core reproduction](../primitives/binohash-legacy-core.md)
+for opcode-boundary deletion, subset-dependent legacy sighashes, and the
+`SIGHASH_SINGLE` bug constant. It does not implement the two-round grinding
+protocol, ECDSA nonce generation, or a complete legacy spend. Do not model
+Binohash with the default tapscript executor: its legacy signature context and
+transaction template are essential semantics. Full reproduction still requires
+a pinned Bitcoin Core regtest, exact grinding parameters, mutation constraints,
+and complete transaction costs. See `introspection/binohash` and `OP-011`.

--- a/research/binohash-legacy-core/README.md
+++ b/research/binohash-legacy-core/README.md
@@ -1,0 +1,35 @@
+# Binohash legacy core reproduction
+
+- **Question:** Can the deterministic FindAndDelete plus legacy-sighash core of
+  Binohash be reproduced locally without conflating it with tapscript execution?
+- **Hypothesis:** Opcode-boundary deletion followed by rust-bitcoin's legacy
+  sighash gives a stable subset-dependent digest, including the historical
+  `SIGHASH_SINGLE` bug constant.
+- **Threat model:** Candidate signatures and selected indices are hostile;
+  malformed selections and invalid input indices must fail. Full Binohash
+  security additionally requires valid legacy signatures and a pinned transaction
+  template.
+- **Comparison objective:** Establish the deterministic core boundary before
+  attempting grinding or complete regtest validation.
+- **Execution class:** host-side legacy serialization; `unclassified`.
+- **Hard constraints:** deletion only at Script opcode boundaries; raw sighash
+  flags preserved; no tapscript or policy assumptions.
+
+## Reproduction
+
+```sh
+cargo test --locked binohash --lib
+```
+
+The external reference suite can be checked with:
+
+```sh
+PYTHONPATH=src uv run --with python-bitcoinlib python -m unittest discover -s tests -p 'test_*.py'
+```
+
+## Result
+
+The Rust core passes four focused tests: aligned deletion, subset-dependent
+legacy digests, the `SIGHASH_SINGLE` bug constant, and hostile input handling.
+The external experiment repository passes eight covered Python tests. No
+complete transaction or Core differential result is claimed.

--- a/src/introspection/README.md
+++ b/src/introspection/README.md
@@ -1,0 +1,19 @@
+# Legacy transaction introspection
+
+This module contains host-side research helpers for transaction-dependent
+legacy Script behavior. They are not tapscript fragments and must not be
+executed with the repository's default tapscript-only assumptions.
+
+## Binohash core
+
+`binohash::find_and_delete` removes selected serialized signature pushes only
+when they occur at Script opcode boundaries. `binohash::binohash_digest` then
+passes the mutated `scriptCode` to rust-bitcoin's legacy sighash implementation.
+This reproduces the deterministic mutation boundary used by a Binohash-style
+subset grind; the proof-of-work search, signature construction, and complete
+legacy transaction execution remain outside this helper.
+
+The focused tests cover opcode-boundary deletion, subset-dependent digests,
+the legacy `SIGHASH_SINGLE` bug constant, invalid selections, and invalid input
+indices. Evidence is local host-side reproduction only; it is not consensus or
+relay-policy validation.

--- a/src/introspection/binohash.rs
+++ b/src/introspection/binohash.rs
@@ -1,0 +1,221 @@
+//! Deterministic Binohash-style legacy sighash mutation.
+//!
+//! This is a host-side legacy transaction primitive, not a tapscript fragment.
+//! It models the opcode-boundary FindAndDelete step used by legacy
+//! `OP_CHECKMULTISIG` before calculating a legacy signature hash.
+
+use bitcoin::{hashes::Hash, sighash::SighashCache, Script, ScriptBuf, Transaction};
+
+/// Errors returned by the deterministic Binohash digest helper.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BinohashError {
+    /// A selected dummy-signature index is outside the supplied candidate set.
+    InvalidSelection,
+    /// The requested transaction input does not exist.
+    InvalidInputIndex,
+}
+
+/// Encode one byte vector as a Bitcoin Script push.
+pub fn push_data(data: &[u8]) -> Vec<u8> {
+    match data.len() {
+        0..=75 => std::iter::once(data.len() as u8)
+            .chain(data.iter().copied())
+            .collect(),
+        76..=255 => std::iter::once(0x4c)
+            .chain(std::iter::once(data.len() as u8))
+            .chain(data.iter().copied())
+            .collect(),
+        256..=0xffff => std::iter::once(0x4d)
+            .chain((data.len() as u16).to_le_bytes())
+            .chain(data.iter().copied())
+            .collect(),
+        _ => std::iter::once(0x4e)
+            .chain((data.len() as u32).to_le_bytes())
+            .chain(data.iter().copied())
+            .collect(),
+    }
+}
+
+fn next_sop(script: &[u8], index: usize) -> usize {
+    if index >= script.len() {
+        return script.len();
+    }
+    let opcode = script[index];
+    let mut next = index + 1;
+    match opcode {
+        0x01..=0x4b => next += opcode as usize,
+        0x4c if next < script.len() => next += 1 + script[next] as usize,
+        0x4d if next + 1 < script.len() => {
+            next += 2 + u16::from_le_bytes([script[next], script[next + 1]]) as usize
+        }
+        0x4e if next + 3 < script.len() => {
+            next += 4 + u32::from_le_bytes([
+                script[next],
+                script[next + 1],
+                script[next + 2],
+                script[next + 3],
+            ]) as usize
+        }
+        _ => {}
+    }
+    next.min(script.len())
+}
+
+fn find_and_delete_one(script: &[u8], pushed_signature: &[u8]) -> Vec<u8> {
+    if pushed_signature.is_empty() {
+        return script.to_vec();
+    }
+    let mut output = Vec::with_capacity(script.len());
+    let mut last_sop = 0;
+    let mut sop = 0;
+    let mut skip = true;
+
+    while sop < script.len() {
+        if !skip {
+            output.extend_from_slice(&script[last_sop..sop]);
+        }
+        last_sop = sop;
+        skip = script[sop..].starts_with(pushed_signature);
+        sop = next_sop(script, sop);
+    }
+    if !skip {
+        output.extend_from_slice(&script[last_sop..]);
+    }
+    output
+}
+
+/// Remove each selected signature push at Script opcode boundaries.
+pub fn find_and_delete(script_code: &Script, signatures: &[Vec<u8>]) -> ScriptBuf {
+    signatures.iter().fold(
+        ScriptBuf::from_bytes(script_code.as_bytes().to_vec()),
+        |script, signature| {
+            ScriptBuf::from_bytes(find_and_delete_one(
+                script.as_bytes(),
+                &push_data(signature),
+            ))
+        },
+    )
+}
+
+/// Calculate a Binohash-style digest for a chosen subset of dummy signatures.
+pub fn binohash_digest(
+    transaction: &Transaction,
+    input_index: usize,
+    script_code: &Script,
+    dummy_signatures: &[Vec<u8>],
+    selected_indices: &[usize],
+    hash_type: u32,
+) -> Result<[u8; 32], BinohashError> {
+    let mut selected = Vec::with_capacity(selected_indices.len());
+    for &index in selected_indices {
+        selected.push(
+            dummy_signatures
+                .get(index)
+                .ok_or(BinohashError::InvalidSelection)?
+                .clone(),
+        );
+    }
+    let modified = find_and_delete(script_code, &selected);
+    SighashCache::new(transaction)
+        .legacy_signature_hash(input_index, &modified, hash_type)
+        .map(|digest| digest.to_byte_array())
+        .map_err(|_| BinohashError::InvalidInputIndex)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::{absolute, transaction, Amount, OutPoint, Sequence, TxIn, TxOut, Witness};
+
+    fn transaction_with_two_outputs() -> Transaction {
+        Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![
+                TxOut {
+                    value: Amount::from_sat(1_000),
+                    script_pubkey: ScriptBuf::from_bytes(vec![0x51]),
+                },
+                TxOut {
+                    value: Amount::from_sat(2_000),
+                    script_pubkey: ScriptBuf::from_bytes(vec![0x51]),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn deletes_only_opcode_aligned_signature_pushes() {
+        let signature = b"sig".to_vec();
+        let script = ScriptBuf::from_bytes(
+            [
+                push_data(&signature),
+                push_data(b"sig inside data"),
+                vec![0x51],
+                push_data(&signature),
+            ]
+            .concat(),
+        );
+        let deleted = find_and_delete(&script, &[signature]);
+        assert_eq!(
+            deleted.as_bytes(),
+            &[
+                0x0f, b's', b'i', b'g', b' ', b'i', b'n', b's', b'i', b'd', b'e', b' ', b'd', b'a',
+                b't', b'a', 0x51
+            ]
+        );
+    }
+
+    #[test]
+    fn subset_selection_changes_legacy_digest() {
+        let transaction = transaction_with_two_outputs();
+        let signatures = vec![b"sig0".to_vec(), b"sig1".to_vec(), b"sig2".to_vec()];
+        let script = ScriptBuf::from_bytes(
+            signatures
+                .iter()
+                .flat_map(|signature| push_data(signature))
+                .chain([0x51])
+                .collect(),
+        );
+        let empty = binohash_digest(&transaction, 0, &script, &signatures, &[], 1).unwrap();
+        let one = binohash_digest(&transaction, 0, &script, &signatures, &[1], 1).unwrap();
+        assert_ne!(empty, one);
+    }
+
+    #[test]
+    fn reproduces_legacy_single_bug_digest() {
+        let mut transaction = transaction_with_two_outputs();
+        let script = ScriptBuf::new();
+        let digest = binohash_digest(&transaction, 0, &script, &[], &[], 3).unwrap();
+        let bug_digest = [
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ];
+        assert_ne!(digest, bug_digest);
+
+        transaction.input.push(transaction.input[0].clone());
+        transaction.output.pop();
+        let digest = binohash_digest(&transaction, 1, &script, &[], &[], 3).unwrap();
+        assert_eq!(digest, bug_digest);
+    }
+
+    #[test]
+    fn rejects_invalid_selection_and_input() {
+        let transaction = transaction_with_two_outputs();
+        let script = ScriptBuf::new();
+        assert_eq!(
+            binohash_digest(&transaction, 0, &script, &[], &[0], 1),
+            Err(BinohashError::InvalidSelection)
+        );
+        assert_eq!(
+            binohash_digest(&transaction, 2, &script, &[], &[], 1),
+            Err(BinohashError::InvalidInputIndex)
+        );
+    }
+}

--- a/src/introspection/mod.rs
+++ b/src/introspection/mod.rs
@@ -1,0 +1,3 @@
+//! Legacy transaction-introspection research primitives.
+
+pub mod binohash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,6 @@ pub mod commitments;
 pub mod curves;
 pub mod fields;
 pub mod hashes;
+pub mod introspection;
 pub mod signatures;
 pub mod support;


### PR DESCRIPTION
## Summary

- reproduce opcode-boundary legacy FindAndDelete semantics
- expose subset-dependent legacy sighashes, including the SIGHASH_SINGLE bug constant
- document the deterministic boundary separately from the full Binohash grinding protocol

## Validation

- cargo fmt --all -- --check
- cargo test --locked binohash --lib
- python3 tools/kb.py validate
- git diff --check

The full repository test suite was intentionally not run; this contribution is host-side legacy behavior and has no tapscript metric.