### PR TITLE
docs(research): record Taproot Merkle path boundary

### DIFF
--- a/knowledge/comparisons/commitments.md
+++ b/knowledge/comparisons/commitments.md
@@ -14,3 +14,10 @@ the four-way path saves 67 script bytes, 17 witness bytes, and 15 peak stack
 items relative to the binary path. This comparison does not erase its stronger
 tapscript-only execution assumption or its non-standard mixed-hash security
 assumption.
+
+Taproot Merkle branches are intentionally absent from this cost table. The
+native-byte adapter search is an inspected negative result: current Script
+cannot bind two hostile 32-byte nodes into the tagged `TapBranch` SHA256
+preimage without an enabled concatenation/splitting operation. See
+[NR-047](../negative-results/index.md#nr-047-native-taproot-merkle-branch-adapter-is-not-available)
+and [OP-020](../open-problems.md#op-020--taproot-merkle-path-verifier).

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,13 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+
+## NR-047: Native Taproot Merkle-branch adapter is not available
+
+Taproot `TapBranch` requires tagged SHA256 over the lexicographically ordered
+concatenation of two hostile 32-byte nodes. Current Script can hash one stack
+item but has no enabled native byte concatenation/splitting boundary, so a
+compact adapter cannot bind separately supplied nodes to a 64-byte witness
+blob. The repository's mixed-hash path commits to nested SHA256/RIPEMD160
+outputs and is not TapBranch. A full u4 SHA256 circuit remains possible but is
+not a compact native primitive; this inspected result is tracked under OP-020.

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -15,6 +15,16 @@ The current zero-key baseline is 6,136 bytes and a 633-item peak. Table packing
 and algebraic sketches without a priced executable circuit do not satisfy
 this criterion; see [the layout search](negative-results/princev2-layout.md).
 
+## OP-020 — Taproot Merkle-path verifier
+
+Resolve the missing dynamic byte boundary for Taproot `TapBranch` verification.
+**Complete when:** either a sound native-opcode or Script-circuit verifier
+accepts hostile leaf/sibling/direction inputs with exact tagged SHA256
+semantics and reports script, witness, hints, stack, and execution costs, or a
+machine-checkable lower-bound argument establishes that the current opcode set
+cannot bind the two 32-byte nodes without a general byte-concatenation circuit.
+The current inspected negative result is [NR-047](negative-results/index.md#nr-047-native-taproot-merkle-branch-adapter-is-not-available).
+
 ## OP-001 — Strict execution matrix
 
 Add explicit legacy/P2WSH/tapscript strict and research-unlimited execution

--- a/research/taproot-merkle-path-negative/README.md
+++ b/research/taproot-merkle-path-negative/README.md
@@ -1,0 +1,34 @@
+# Taproot Merkle-path verifier negative result
+
+- **Question:** Can current Bitcoin Script verify one dynamic Taproot Merkle
+  branch using only native byte-string/hash opcodes?
+- **Hypothesis:** A compact native verifier is unavailable because TapBranch
+  hashes the lexicographically ordered concatenation of two 32-byte nodes, but
+  Script cannot concatenate or split arbitrary byte strings.
+- **Comparison objective:** Distinguish the missing native byte boundary from
+  the repository's mixed-hash path commitments, which deliberately nest fixed
+  hash outputs and therefore do not implement TapBranch.
+- **Threat model:** Leaf hashes, sibling nodes, and left/right selectors are
+  hostile. A verifier that hashes an unbound 64-byte witness blob is unsound
+  because it does not prove that the blob contains the separately supplied
+  nodes.
+- **Execution class:** `unclassified`; this is an inspected negative result,
+  not an executed Script primitive.
+- **Hard constraints:** no disabled opcode assumptions, no opaque host-side
+  concatenation, and the Taproot `TapBranch` tag and lexicographic ordering
+  must remain exact.
+
+## Result
+
+`OP_SHA256` hashes one stack item, but current Script has no enabled native
+byte concatenation or split operation that can construct and bind
+`left || right` from two hostile 32-byte stack items. The existing mixed-hash
+path is not a substitute: it hashes a preimage through nested SHA256/RIPEMD160
+branches and ends in HASH160, rather than reproducing TapBranch's tagged
+SHA256. A u4 SHA256 circuit could implement the byte boundary, but that is the
+full hash-circuit problem and requires a separate costed construction; no
+compact native adapter is retained here.
+
+The relevant local reference is
+[`knowledge/bitcoin-script-reference.md`](../../knowledge/bitcoin-script-reference.md)
+for opcode availability and Taproot branch semantics. See NR-047 and OP-020.


### PR DESCRIPTION
## Summary

- document why a compact native Taproot Merkle-branch adapter cannot bind two hostile 32-byte nodes with the current opcode set
- distinguish the missing byte-concatenation boundary from the repository's mixed-hash path commitments
- add OP-020 to track either a sound full circuit or a machine-checkable lower bound

## Validation

- python3 tools/kb.py validate
- git diff --check

This is an inspected negative result; no deployment or cryptographic claim is made.