### PR TITLE
docs(research): track constant-composition decoder boundary

### DIFF
--- a/knowledge/comparisons/signatures.md
+++ b/knowledge/comparisons/signatures.md
@@ -381,3 +381,8 @@ See the [constant-sum primitive](../primitives/winternitz-constant-sum20.md)
 for exact code capacity, public API, proof scope, hash alternatives,
 independent Python reproduction, and [NR-041](../negative-results/index.md#nr-041-20-byte-winternitz-search-and-overflow-relation-boundaries)
 for the restricted radix search and rejected zero-fixture-only improvements.
+
+The constant-composition verifier intentionally has no Script byte-recovery
+row. Its host-side rank decoder is not included in the authentication costs;
+the missing consumer boundary is tracked by [NR-048](../negative-results/index.md#nr-048-constant-composition-byte-recovery-is-not-yet-a-composable-script-primitive)
+and [OP-021](../open-problems.md#op-021--constant-composition-script-decoder).

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,12 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+
+## NR-048: Constant-composition byte recovery is not yet a composable Script primitive
+
+The fixed-composition Winternitz verifier locally authenticates 49 digit slots,
+but its 20-byte decoder remains host-side. Exact rank recovery needs dynamic
+multinomial buckets and 160-bit arithmetic; a static replacement would need a
+large position/count/digit table whose Script lifetime and stack cost are not
+yet established. Treating the host `decode_message` helper as Script evidence
+would overstate the construction. The boundary remains under OP-021.

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -15,6 +15,16 @@ The current zero-key baseline is 6,136 bytes and a 633-item peak. Table packing
 and algebraic sketches without a priced executable circuit do not satisfy
 this criterion; see [the layout search](negative-results/princev2-layout.md).
 
+## OP-021 — Constant-composition Script decoder
+
+Recover the canonical 20-byte message from the 49-digit fixed-composition
+Winternitz encoding inside Script. **Complete when:** a decoder rejects hostile
+length, radix, composition, and unused-rank inputs; returns exactly 20
+canonical bytes; reports script, witness, hint, stack, executed-opcode, and
+execution-class costs; and is compared against the host `decode_message` helper
+on deterministic boundary vectors. The current inspected non-composable
+boundary is documented in `research/constant-composition-decoder-negative`.
+
 ## OP-001 — Strict execution matrix
 
 Add explicit legacy/P2WSH/tapscript strict and research-unlimited execution

--- a/research/constant-composition-decoder-negative/README.md
+++ b/research/constant-composition-decoder-negative/README.md
@@ -1,0 +1,33 @@
+# Constant-composition Script decoder negative result
+
+- **Question:** Can the 49-digit constant-composition Winternitz encoding be
+  decoded back to its 20-byte rank inside Bitcoin Script at a composable cost?
+- **Hypothesis:** The existing host decoder does not translate compactly: exact
+  lexicographic ranking requires dynamic multinomial buckets, 160-bit rank
+  accumulation, and division-like updates that current Script does not provide
+  as a native opcode.
+- **Comparison objective:** Keep the existing 2,400-byte terminal verifier
+  boundary focused on authentication, and avoid silently treating its host
+  `decode_message` helper as a Script consumer.
+- **Threat model:** All 49 digit values are hostile. A decoder must reject the
+  wrong length, out-of-radix values, duplicate/exhausted composition counts,
+  and ranks outside the first `2^160` codewords.
+- **Execution class:** `unclassified`; inspected design result, with no Script
+  decoder claimed.
+- **Hard constraints:** preserve the exact composition, recover canonical
+  big-endian 20-byte output, and count all tables, rank state, witness items,
+  and stack state under the same 1,000-item boundary.
+
+## Result
+
+`ConstantCompositionWinternitz20::decode_message` is already a deterministic
+host utility. Porting it directly would require dynamic multinomial bucket
+selection and 160-bit arithmetic for every digit position; replacing the
+divisions with a static table would expose a large position/count/digit table
+whose lifetime and stack cost have not been priced. The authentication
+verifier does not need recovered bytes and intentionally leaves this boundary
+to a consumer. No compact Script decoder is retained.
+
+This is not a lower bound against a future circuit or a claim that recovery is
+impossible. It records the current non-composable boundary and points to
+OP-021 for a properly costed decoder experiment.


### PR DESCRIPTION
## Summary

- document the host-only constant-composition Winternitz byte decoder boundary
- record why dynamic multinomial ranking is not yet a composable Script primitive
- add OP-021 with a falsifiable acceptance criterion and a negative result

## Validation

- python3 tools/kb.py validate
- git diff --check

This is an inspected research boundary, not a claim that a future full Script decoder is impossible.