### PR TITLE
test(research): add Binohash Core regtest smoke fixture

### DIFF
--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,12 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+
+## NR-049: Ordinary Core P2SH validation is not Binohash reproduction
+
+The disposable Core-regtest fixture accepts a complete 1-of-1 legacy P2SH
+`OP_CHECKMULTISIG` spend and exercises the ordinary legacy transaction
+boundary. It does not place candidate signatures inside a Binohash mutation
+template, extract a Script-readable digest, or measure grinding work. Treating
+this smoke result as Binohash evidence would conflate a prerequisite execution
+check with the protocol; the full reproduction remains under OP-011.

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -246,6 +246,11 @@ linked, and the catalog-wide `as_of` date is advanced.
 
 ## OP-011 — Reproduce Binohash
 
+Progress: a disposable Bitcoin Core regtest now accepts a complete ordinary
+legacy 1-of-1 P2SH `OP_CHECKMULTISIG` spend with a 37-byte redeem script. This
+does not reproduce Binohash's signature grinding, mutation-dependent digest,
+or collision/work parameters; those remain the completion target.
+
 Implement the specified legacy signature-grinding construction and validate it
 against a pinned Bitcoin Core regtest. **Complete when:** extraction correctness,
 collision/work parameters, full transaction costs, mutation boundaries, and

--- a/knowledge/primitives/binohash.md
+++ b/knowledge/primitives/binohash.md
@@ -6,14 +6,16 @@ transaction-dependent digest that Bitcoin Script can extract and authenticate.
 
 - **Position:** external state-of-the-art transaction introspection construction
   that requires no consensus change, according to its primary source.
-- **Evidence:** reported and inspected at the paper/discussion level; no local
-  implementation or reproduction is present.
+- **Evidence:** the full protocol remains reported and inspected at the
+  paper/discussion level. A separate [Core-regtest smoke fixture](../../research/binohash-core-regtest/README.md)
+  now reproduces an ordinary legacy P2SH spend, but not Binohash itself.
 - **Reported profile:** the paper proposes a two-round nonce extraction design
   with tunable work/collision parameters and a Lamport-signable output.
 - **Execution context:** relies on legacy signature semantics, not the local
   tapscript-only executor defaults.
-- **Research need:** pin a reference implementation, reproduce Core regtest
-  behavior, catalog full script/witness/work costs, and model grinding economics.
+- **Research need:** pin a reference implementation, reproduce Binohash-specific
+  Core regtest behavior, catalog full script/witness/work costs, and model
+  grinding economics.
 
 See source `binohash-paper`, the [transaction-introspection discussion](https://delvingbitcoin.org/t/binohash-transaction-introspection-without-softforks/2288),
 and open problem `OP-011`.

--- a/knowledge/protocols/transaction-introspection.md
+++ b/knowledge/protocols/transaction-introspection.md
@@ -13,8 +13,11 @@ Transaction mutations and legacy sighash
 └── Lamport authentication into a later verification protocol
 ```
 
-The current atlas has no local implementation. Do not model Binohash with the
-default tapscript executor: its legacy signature context and transaction
-template are essential semantics. Reproduction requires a pinned Bitcoin Core
-regtest, exact grinding parameters, mutation constraints, and full transaction
-costs. See `introspection/binohash` and `OP-011`.
+The repository now has a disposable [Core-regtest smoke fixture](../../research/binohash-core-regtest/README.md)
+for an ordinary legacy P2SH `OP_CHECKMULTISIG` spend. It is only an execution
+precondition: it does not implement Binohash, extract its digest, or reproduce
+grinding. Do not model Binohash with the default tapscript executor: its legacy
+signature context and transaction template are essential semantics. Full
+reproduction still requires a pinned Core regtest, exact grinding parameters,
+mutation constraints, and complete transaction costs. See `introspection/binohash`
+and `OP-011`.

--- a/research/binohash-core-regtest/README.md
+++ b/research/binohash-core-regtest/README.md
@@ -1,0 +1,33 @@
+# Binohash Core-regtest smoke fixture
+
+- **Question:** Can the local environment reproduce a complete ordinary legacy
+  P2SH `OP_CHECKMULTISIG` spend, the execution context required before a
+  Binohash reproduction is attempted?
+- **Hypothesis:** A disposable Core regtest can accept a deterministic 1-of-1
+  legacy P2SH spend signed by a fixed test key, establishing the basic legacy
+  transaction boundary without claiming Binohash extraction.
+- **Comparison objective:** Separate ordinary Core legacy validation from the
+  full Binohash protocol, which still needs signature grinding, mutation
+  fixtures, digest extraction, and collision/work measurements.
+- **Threat model:** The redeem script, signature, and transaction fields are
+  treated as hostile by Core; the fixture uses a fixed test-only key and checks
+  only completed signing and mempool acceptance.
+- **Execution class:** Core regtest smoke evidence; not a cataloged Script
+  primitive and not a deployment claim.
+- **Hard constraints:** temporary regtest datadir, no persistent wallet state,
+  legacy P2SH only, and no reuse of the test key for funds.
+
+## Reproduction
+
+```sh
+research/binohash-core-regtest/run.sh
+```
+
+The local run used Bitcoin Core v30.2.0 and produced a 37-byte 1-of-1 redeem
+script, `signed_transaction_complete=True`, and successful raw-transaction
+acceptance. Pin an exact Core commit and add a Binohash-specific transaction
+fixture before promoting this smoke result to differential evidence.
+
+This fixture does not reproduce the paper's two-round grinding protocol, does
+not expose a transaction digest to Script, and does not establish collision
+resistance or honest-work bounds.

--- a/research/binohash-core-regtest/run.sh
+++ b/research/binohash-core-regtest/run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+datadir=$(mktemp -d)
+base_cli=(bitcoin-cli -regtest -datadir="$datadir")
+cleanup() { "${base_cli[@]}" stop >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+bitcoind -regtest -datadir="$datadir" -fallbackfee=0.0001 -daemonwait >/dev/null
+"${base_cli[@]}" createwallet binohash >/dev/null
+wallet_cli=(bitcoin-cli -regtest -datadir="$datadir" -rpcwallet=binohash)
+
+json_field() {
+    python3 -c 'import json,sys; print(json.load(sys.stdin)[sys.argv[1]])' "$1"
+}
+
+# Test-only private key 1; its public key is fixed and not used for funds.
+test_wif=$(python3 - <<'PY'
+import hashlib
+
+alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+secret = (1).to_bytes(32, "big")
+payload = bytes([239]) + secret + bytes([1])
+value = payload + hashlib.sha256(hashlib.sha256(payload).digest()).digest()[:4]
+number = int.from_bytes(value, "big")
+encoded = ""
+while number:
+    number, remainder = divmod(number, 58)
+    encoded = alphabet[remainder] + encoded
+print(alphabet[0] * (len(value) - len(value.lstrip(bytes([0])))) + encoded)
+PY
+)
+test_pubkey=0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+
+funding_address=$("${wallet_cli[@]}" getnewaddress)
+"${base_cli[@]}" generatetoaddress 101 "$funding_address" >/dev/null
+multisig=$("${base_cli[@]}" createmultisig 1 "[\"$test_pubkey\"]")
+p2sh_address=$(printf %s "$multisig" | json_field address)
+redeem_script=$(printf %s "$multisig" | json_field redeemScript)
+fund_txid=$("${wallet_cli[@]}" sendtoaddress "$p2sh_address" 1)
+"${base_cli[@]}" generatetoaddress 1 "$funding_address" >/dev/null
+
+fund_raw=$("${wallet_cli[@]}" gettransaction "$fund_txid" | json_field hex)
+decoded=$("${base_cli[@]}" decoderawtransaction "$fund_raw")
+utxo=$(printf %s "$decoded" | python3 -c '
+import json, sys
+tx = json.load(sys.stdin)
+address = sys.argv[1]
+output = next(o for o in tx["vout"] if o["scriptPubKey"].get("address") == address)
+print(tx["txid"], output["n"], output["scriptPubKey"]["hex"], output["value"])
+' "$p2sh_address")
+read -r spend_txid spend_vout prev_script prev_amount <<<"$utxo"
+
+raw=$("${base_cli[@]}" createrawtransaction \
+    "[{\"txid\":\"$spend_txid\",\"vout\":$spend_vout}]" \
+    "{\"$funding_address\":0.999}")
+prevtx=$(printf '[{"txid":"%s","vout":%s,"scriptPubKey":"%s","redeemScript":"%s","amount":%s}]' \
+    "$spend_txid" "$spend_vout" "$prev_script" "$redeem_script" "$prev_amount")
+signed=$("${base_cli[@]}" signrawtransactionwithkey "$raw" "[\"$test_wif\"]" "$prevtx")
+signed_hex=$(printf %s "$signed" | json_field hex)
+complete=$(printf %s "$signed" | json_field complete)
+"${base_cli[@]}" sendrawtransaction "$signed_hex" >/dev/null
+
+printf 'core_version=%s\n' "$(bitcoind -version | head -1)"
+printf 'p2sh_redeem_script_bytes=%s\n' "$(( ${#redeem_script} / 2 ))"
+printf 'signed_transaction_complete=%s\n' "$complete"
+printf 'legacy_p2sh_spend_accepted=true\n'


### PR DESCRIPTION
## Summary

- add a disposable Bitcoin Core regtest fixture for a complete legacy 1-of-1 P2SH OP_CHECKMULTISIG spend
- record the 37-byte redeem-script and successful raw-transaction acceptance boundary
- explicitly separate this prerequisite smoke test from full Binohash grinding and digest reproduction

## Validation

- research/binohash-core-regtest/run.sh
- python3 tools/kb.py validate
- git diff --check

The fixture uses a temporary datadir and a fixed test-only private key; no persistent wallet state is retained.