### PR TITLE
docs(research): record ScriptNum canonicality boundary

### DIFF
--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -3,6 +3,17 @@
 These records prevent repeated dead ends. They are scoped observations, not
 universal impossibility proofs.
 
+## NR-051: General ScriptNum byte canonicality is unavailable with current opcodes
+
+The enabled opcode set exposes numeric comparison and `OP_SIZE`, but not an
+enabled `OP_SPLIT`, `OP_NUM2BIN`, or equivalent byte-extraction/normalization
+primitive. A verifier can establish a numeric range while remaining unable to
+distinguish negative-zero or redundant sign padding in an arbitrary hostile
+stack item. Relay-policy `MINIMALDATA` rejects some non-minimal pushes, but it
+is not a consensus binding for every script context. This is an `inspected`
+boundary result, not a universal impossibility proof; a future byte primitive
+or fixed-width protocol encoding could close it. See [OP-022](../open-problems.md#op-022--scriptnum-byte-canonicality-adapter).
+
 ## NR-037: PRINCEv2 shared-selector corrections outweigh memory savings
 
 The [PRINCEv2 layout search](princev2-layout.md) records the discarded shared

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -15,6 +15,16 @@ The current zero-key baseline is 6,136 bytes and a 633-item peak. Table packing
 and algebraic sketches without a priced executable circuit do not satisfy
 this criterion; see [the layout search](negative-results/princev2-layout.md).
 
+## OP-022 — ScriptNum byte canonicality adapter
+
+Define and measure a consensus-scoped adapter that rejects negative-zero and
+redundant sign padding for hostile ScriptNum byte strings. **Complete when:**
+the adapter has executable boundary tests, distinguishes numeric equality from
+raw-byte equality, and reports its conversion cost under legacy, P2WSH, and
+tapscript rules. The current enabled opcode set has no general byte-slicing or
+`NUM2BIN` normalization path, so range checks alone do not close this problem;
+see [NR-051](negative-results/index.md#nr-051-general-scriptnum-byte-canonicality-is-unavailable-with-current-opcodes).
+
 ## OP-001 — Strict execution matrix
 
 Add explicit legacy/P2WSH/tapscript strict and research-unlimited execution

--- a/research/scriptnum-canonicality-negative/README.md
+++ b/research/scriptnum-canonicality-negative/README.md
@@ -1,0 +1,40 @@
+# ScriptNum canonical-byte boundary
+
+## Question
+
+Can enabled Bitcoin Script opcodes prove that a hostile stack item is the
+unique minimally encoded byte representation of a ScriptNum, independent of
+relay-policy `MINIMALDATA` enforcement?
+
+## Finding
+
+The current repository exposes `OP_SIZE` and numeric comparisons, but no
+enabled byte-slicing primitive (`OP_SPLIT` is disabled) and no `OP_NUM2BIN`
+normalization path. Numeric interpretation therefore cannot inspect the
+highest serialized byte needed to reject negative-zero and redundant sign
+padding for arbitrary-width inputs. A caller can validate a numeric range, but
+that does not bind the raw byte representation.
+
+This is an `inspected` boundary result, not an impossibility proof. A future
+byte primitive, a fixed-width protocol encoding, or policy-level
+`MINIMALDATA` enforcement could change the result. Consensus-sensitive
+protocols must not silently promote policy minimality to a consensus property.
+
+## Reproduction
+
+The opcode inventory and existing canonicality notes can be checked with:
+
+```sh
+rg -n 'OP_SPLIT|OP_NUM2BIN|OP_BIN2NUM|MINIMALDATA|OP_SIZE' src knowledge
+```
+
+Related local code documents numeric-range checks without byte-unique binding
+in [`src/arithmetic/u4/README.md`](../../src/arithmetic/u4/README.md) and
+[`knowledge/primitives/u4.md`](../../knowledge/primitives/u4.md).
+
+## Acceptance criterion
+
+Close this result only with an executable, consensus-scoped adapter that
+rejects negative-zero, redundant sign padding, and boundary-width encodings,
+or with a fixed-width protocol design that makes raw-byte uniqueness
+unnecessary and measures its conversion cost.


### PR DESCRIPTION
## Summary
- document the current lack of a consensus-scoped general ScriptNum byte-canonicality adapter
- distinguish numeric range checks from raw-byte uniqueness and relay-policy MINIMALDATA
- add NR-051 and falsifiable OP-022 acceptance criteria

## Validation
- `python3 tools/kb.py validate`
- `git diff --check`
