### PR TITLE
feat(u4): add lexicographic vector comparison

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -117,6 +117,74 @@
       ]
     },
     {
+      "id": "arithmetic/u4-lexicographic",
+      "name": "Fixed-width u4 lexicographic comparison",
+      "class": "arithmetic/word",
+      "summary": "Range-checks and compares two equal-width big-endian u4 vectors, consuming both and returning left-less-than-or-equal-to-right.",
+      "status": "active",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/u4-lexicographic.md",
+      "implementation": "src/arithmetic/u4/compare.rs",
+      "documentation": "src/arithmetic/u4/README.md",
+      "tests": [
+        "arithmetic::u4::compare::tests::compares_all_two_nibble_values",
+        "arithmetic::u4::compare::tests::rejects_an_out_of_range_nibble",
+        "arithmetic::u4::compare::tests::rejects_zero_width",
+        "primitive_metrics::u4_lexicographic_metrics_are_current"
+      ],
+      "references": [
+        "bip-342",
+        "bitcoin-scriptexec-locked",
+        "bitcoin-script-locked"
+      ],
+      "techniques": [
+        "digit-arithmetic",
+        "lexicographic-comparison",
+        "range-check"
+      ],
+      "security": "No independent cryptographic claim. Hostile inputs are numerically range-checked before comparison; raw byte-unique ScriptNum canonicality remains a separate protocol obligation.",
+      "stack_contract": "left[0] ... left[n-1] right[0] ... right[n-1] -> result, with each vector big-endian and each item in 0..=15",
+      "configurations": [
+        {
+          "id": "two-128-nibble-vectors",
+          "label": "Two 128-nibble vectors",
+          "parameters": {
+            "nibble_count_per_operand": 128,
+            "input_items": 256,
+            "ordering": "most-significant nibble first",
+            "hints": 0
+          },
+          "includes": "fragment-only: 256 numeric range checks, first-difference state machine, operand cleanup, and complete 256-item witness boundary; excludes hash composition, terminal predicate, and transaction context",
+          "script_bytes": 7500,
+          "witness_bytes": 259,
+          "witness_bytes_max": 515,
+          "max_stack_items": 259,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 7500,
+          "metric_keys": [
+            "u4_lexicographic_le_128",
+            "u4_lexicographic_le_128_witness",
+            "u4_lexicographic_le_128_stack"
+          ]
+        }
+      ],
+      "limitations": [
+        "Fixed-width u4 vectors only",
+        "Numeric nibble checks do not prove unique raw ScriptNum byte encodings",
+        "4,354 static non-push opcodes exceed the 201-opcode legacy/P2SH/P2WSH policy boundary",
+        "Bitcoin Core consensus and relay-policy validation have not been performed"
+      ],
+      "open_problems": [
+        "OP-001",
+        "OP-002",
+        "OP-003"
+      ]
+    },
+    {
       "id": "arithmetic/u4",
       "name": "u4 digit arithmetic",
       "class": "arithmetic/word",

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Fixed-width u4 ordering | `lexicographic_le(128)` | 7,500 | 256 data items; 4,354 non-push opcodes |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -9,6 +9,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [ScriptNum constant multiplication](scriptnum-constant-mul.md)
 - [Hinted ScriptNum division](scriptnum-hinted-div.md)
 - [u4 digit arithmetic](u4.md)
+- [Fixed-width u4 lexicographic comparison](u4-lexicographic.md)
 - [u32 word arithmetic](u32.md)
 - [u31 prime-field arithmetic](u31.md)
 - [Native secp256k1 base-field arithmetic](secp256k1-field.md)

--- a/knowledge/primitives/u4-lexicographic.md
+++ b/knowledge/primitives/u4-lexicographic.md
@@ -1,0 +1,51 @@
+# Fixed-width u4 lexicographic comparison
+
+`arithmetic::u4::compare::lexicographic_le` compares two equal-width,
+big-endian u4 vectors and returns whether `left <= right`. It range-checks all
+hostile input nibbles before looking at the first differing position, consumes
+both vectors, and leaves one truthy/falsy result. The primitive is useful for
+Taproot node ordering and other fixed-width byte-domain commitments.
+
+## Contract
+
+For `n > 0`:
+
+```text
+left[0] ... left[n-1] right[0] ... right[n-1] -> result
+```
+
+Each input is one numeric nibble in `0..=15`, ordered most-significant first.
+The result is true for equality and for the first differing nibble being lower
+on the left. The implementation uses no witness hints; the `2*n` data items
+all coexist at script entry.
+
+The range check establishes numeric nibble validity. It does not establish a
+unique raw ScriptNum byte encoding under consensus; callers that need byte
+canonicality must use a separately specified policy or encoding boundary.
+
+## Measurement
+
+The representative `n=128` fragment includes all numeric range checks, the
+first-difference state machine, operand cleanup, and a complete 256-item empty
+nibble witness. It excludes any surrounding hash, terminal predicate, or
+transaction context.
+
+| Configuration | Script | Witness | Data items | Hints | Peak | Static non-push opcodes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Two 128-nibble vectors | 7,500 bytes | 259 bytes | 256 | 0 (none) | 259 | 4,354 |
+
+The strict local executor enforces the combined 1,000-item stack limit for the
+measurement. Deployment remains `unclassified`: the fragment is below the
+10,000-byte script-size ceiling but has more than 201 non-push opcodes and has
+not been differentially validated against Bitcoin Core.
+
+## Validation
+
+The focused test exhaustively checks all `256 × 256` two-nibble byte pairs,
+rejects an out-of-range nibble, and rejects zero-width generation. Run:
+
+```sh
+cargo test --locked arithmetic::u4::compare
+cargo test --locked --test primitive_metrics u4_lexicographic_metrics_are_current
+python3 tools/kb.py validate
+```

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -30,6 +30,7 @@ each input with the same output-restoration boundary.
 | Checked table batch, 32 nibbles | <!-- metric:u4_bits_checked_batch32 -->924<!-- /metric:u4_bits_checked_batch32 --> bytes | <!-- metric:u4_bits_checked_batch32_stack -->189<!-- /metric:u4_bits_checked_batch32_stack --> items | <!-- metric:u4_bits_checked_batch32_opcodes -->735<!-- /metric:u4_bits_checked_batch32_opcodes --> |
 | Unchecked table batch, 32 nibbles | <!-- metric:u4_bits_unchecked_batch32 -->764<!-- /metric:u4_bits_unchecked_batch32 --> bytes | 189 items | not recorded |
 | Existing branch splitter, 32 four-bit limbs | <!-- metric:u4_bits_branch_batch32 -->1374<!-- /metric:u4_bits_branch_batch32 --> bytes | <!-- metric:u4_bits_branch_batch32_stack -->130<!-- /metric:u4_bits_branch_batch32_stack --> items | not recorded |
+| `lexicographic_le(128)` | <!-- metric:u4_lexicographic_le_128 -->7500<!-- /metric:u4_lexicographic_le_128 --> bytes | <!-- metric:u4_lexicographic_le_128_stack -->259<!-- /metric:u4_lexicographic_le_128_stack --> items | <!-- metric:u4_lexicographic_le_128_opcodes -->4354<!-- /metric:u4_lexicographic_le_128_opcodes --> |
 
 The staggered table has 61 setup items and costs 31 bytes to remove. A checked
 query costs 22 bytes and restoring its four bits costs another four, so the
@@ -48,6 +49,11 @@ before using a value as an `OP_PICK` index. `check_inputs=false` must be used
 only when a surrounding fragment already established that range: an invalid
 index can otherwise address below the table. The numeric range check does not
 by itself prove a byte-unique ScriptNum encoding.
+
+`compare::lexicographic_le(n)` range-checks two `n`-nibble big-endian vectors,
+compares the first differing nibble, consumes both vectors, and returns one
+truth value. For the representative 128-nibble vectors, the complete witness
+is <!-- metric:u4_lexicographic_le_128_witness -->259<!-- /metric:u4_lexicographic_le_128_witness --> bytes across <!-- metric:u4_lexicographic_le_128_witness_items -->256<!-- /metric:u4_lexicographic_le_128_witness_items --> data items and <!-- metric:u4_lexicographic_le_128_hints -->0<!-- /metric:u4_lexicographic_le_128_hints --> hint items; all data items coexist at entry. Numeric range validation does not make non-minimal raw ScriptNum encodings byte-unique under consensus.
 
 ## Script compatibility and standardness
 

--- a/src/arithmetic/u4/compare.rs
+++ b/src/arithmetic/u4/compare.rs
@@ -1,0 +1,106 @@
+//! Comparisons over fixed-width big-endian u4 vectors.
+
+use crate::support::script::{script, Script};
+
+use super::stack::u4_drop;
+
+/// Return whether `left <= right` for two fixed-width big-endian u4 vectors.
+///
+/// Stack before: `left[0] ... left[n-1] right[0] ... right[n-1]`.
+/// Stack after: `result`, where both vectors are consumed. Every input is
+/// range-checked as a numeric nibble before the first comparison.
+pub fn lexicographic_le(nibble_count: u32) -> Script {
+    assert!(nibble_count > 0, "comparison width must be nonzero");
+    let input_count = nibble_count * 2;
+
+    script! {
+        for index in 0..input_count {
+            { index }
+            OP_PICK
+            OP_DUP 0 OP_GREATERTHANOREQUAL OP_VERIFY
+            16 OP_LESSTHAN OP_VERIFY
+        }
+
+        // The altstack holds the result; the main stack carries an active flag
+        // while the prefixes remain equal.
+        1 OP_TOALTSTACK
+        1
+        for index in 0..nibble_count {
+            OP_IF
+                // If left < right, the final result is true.
+                { 2 * nibble_count - 1 - index } OP_PICK
+                { nibble_count - index } OP_PICK
+                OP_LESSTHAN
+                OP_IF
+                    OP_FROMALTSTACK OP_DROP
+                    1 OP_TOALTSTACK
+                    0
+                OP_ELSE
+                    // The first comparison was false; test right < left.
+                    { nibble_count - 1 - index } OP_PICK
+                    { 2 * nibble_count - index } OP_PICK
+                    OP_LESSTHAN
+                    OP_IF
+                        OP_FROMALTSTACK OP_DROP
+                        0 OP_TOALTSTACK
+                        0
+                    OP_ELSE
+                        1
+                    OP_ENDIF
+                OP_ENDIF
+            OP_ELSE
+                0
+            OP_ENDIF
+        }
+
+        OP_DROP
+        OP_FROMALTSTACK OP_TOALTSTACK
+        { u4_drop(input_count) }
+        OP_FROMALTSTACK
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        arithmetic::u4::stack::u4_hex_to_nibbles,
+        support::{execution::execute_script, script::script},
+    };
+
+    #[test]
+    fn compares_all_two_nibble_values() {
+        for left in 0..=0xffu16 {
+            for right in 0..=0xffu16 {
+                let left_hex = format!("{left:02x}");
+                let right_hex = format!("{right:02x}");
+                let expected = i64::from(left <= right);
+                let result = execute_script(script! {
+                    { u4_hex_to_nibbles(&left_hex) }
+                    { u4_hex_to_nibbles(&right_hex) }
+                    { lexicographic_le(2) }
+                    { expected } OP_EQUAL
+                });
+                assert!(
+                    result.success,
+                    "left={left:#04x} right={right:#04x}: {result}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_an_out_of_range_nibble() {
+        let result = execute_script(script! {
+            0 16
+            { lexicographic_le(1) }
+        });
+        assert!(!result.success);
+    }
+
+    #[test]
+    #[should_panic(expected = "comparison width must be nonzero")]
+    fn rejects_zero_width() {
+        let _ = lexicographic_le(0);
+    }
+}

--- a/src/arithmetic/u4/mod.rs
+++ b/src/arithmetic/u4/mod.rs
@@ -1,5 +1,6 @@
 pub mod add;
 pub mod bits;
+pub mod compare;
 pub mod logic;
 pub mod rotate;
 pub mod shift;

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4037,6 +4037,44 @@ fn prince_metrics_are_current() {
     check_readme_metrics(prince_metrics());
 }
 
+#[test]
+fn u4_lexicographic_metrics_are_current() {
+    let fragment = u4::compare::lexicographic_le(128);
+    let witness = vec![Vec::new(); 256];
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_lexicographic_le_128",
+            value: script_len(fragment.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_lexicographic_le_128_stack",
+            value: max_stack_items_strict(fragment.clone(), witness.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_lexicographic_le_128_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_lexicographic_le_128_witness_items",
+            value: witness.len(),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_lexicographic_le_128_hints",
+            value: 0,
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_lexicographic_le_128_opcodes",
+            value: static_non_push_opcodes(fragment),
+        },
+    ]);
+}
+
 /// This isolated fixture exercises only the two small packed decoders. It
 /// stays runnable without enabling the ignored repository-wide metric suite.
 #[test]


### PR DESCRIPTION
## Summary
- add a fixed-width big-endian u4 `left <= right` comparator
- range-check all hostile nibbles before first-difference comparison
- consume both operands and return one result with no hints
- add exhaustive two-nibble tests, malformed-input coverage, metrics, and knowledge-base documentation

## Validation
- `cargo test --locked arithmetic::u4::compare`
- `cargo test --locked --test primitive_metrics u4_lexicographic_metrics_are_current`
- `python3 tools/kb.py validate`

Representative 128-nibble vectors measure 7,500 script bytes, 259 witness bytes across 256 data items, 4,354 static non-push opcodes, and a strict 259-item peak.
