### PR TITLE
feat(u4): add checked pair-to-byte packing

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -117,6 +117,75 @@
       ]
     },
     {
+      "id": "arithmetic/u4-pack",
+      "name": "u4 pair-to-byte packing",
+      "class": "arithmetic/word",
+      "summary": "Range-checks big-endian u4 pairs and packs them into numeric ScriptNum byte values.",
+      "status": "active",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/u4-pack.md",
+      "implementation": "src/arithmetic/u4/pack.rs",
+      "documentation": "src/arithmetic/u4/README.md",
+      "tests": [
+        "arithmetic::u4::pack::tests::packs_all_single_bytes",
+        "arithmetic::u4::pack::tests::packs_multiple_bytes_in_input_order",
+        "arithmetic::u4::pack::tests::rejects_an_out_of_range_nibble",
+        "arithmetic::u4::pack::tests::rejects_zero_width",
+        "primitive_metrics::u4_pack_metrics_are_current"
+      ],
+      "references": [
+        "bip-342",
+        "bitcoin-scriptexec-locked",
+        "bitcoin-script-locked"
+      ],
+      "techniques": [
+        "digit-arithmetic",
+        "range-check",
+        "representation-conversion"
+      ],
+      "security": "No independent cryptographic claim. Hostile nibbles are numerically range-checked; output values are ScriptNum integers and do not provide raw-byte concatenation or unique byte encodings.",
+      "stack_contract": "high[0] low[0] ... high[n-1] low[n-1] -> byte[0] ... byte[n-1], with byte[n-1] on top and every output numeric in 0..=255",
+      "configurations": [
+        {
+          "id": "pack-32",
+          "label": "32 packed numeric bytes",
+          "parameters": {
+            "byte_count": 32,
+            "input_items": 64,
+            "output_items": 32,
+            "output_encoding": "minimal ScriptNum integer"
+          },
+          "includes": "fragment-only: 64 numeric range checks, repeated four-doubling packing, output routing, and complete 64-item witness boundary; excludes raw-byte serialization, consumer logic, and transaction context",
+          "script_bytes": 1003,
+          "witness_bytes": 65,
+          "witness_bytes_max": 131,
+          "max_stack_items": 67,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 1003,
+          "metric_keys": [
+            "u4_pack_bytes_32",
+            "u4_pack_bytes_32_witness",
+            "u4_pack_bytes_32_stack"
+          ]
+        }
+      ],
+      "limitations": [
+        "Outputs are numeric ScriptNum values, not raw byte stack elements",
+        "Values 128..255 have multi-byte minimally encoded ScriptNum representations",
+        "766 static non-push opcodes exceed the 201-opcode legacy/P2SH/P2WSH policy boundary",
+        "Bitcoin Core consensus and relay-policy validation have not been performed"
+      ],
+      "open_problems": [
+        "OP-001",
+        "OP-002",
+        "OP-003"
+      ]
+    },
+    {
       "id": "arithmetic/u4",
       "name": "u4 digit arithmetic",
       "class": "arithmetic/word",

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| u4 pair-to-byte packing | `pack_bytes(32)` | 1,003 | Numeric ScriptNum bytes; 766 non-push opcodes |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -9,6 +9,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [ScriptNum constant multiplication](scriptnum-constant-mul.md)
 - [Hinted ScriptNum division](scriptnum-hinted-div.md)
 - [u4 digit arithmetic](u4.md)
+- [u4 pair-to-byte packing](u4-pack.md)
 - [u32 word arithmetic](u32.md)
 - [u31 prime-field arithmetic](u31.md)
 - [Native secp256k1 base-field arithmetic](secp256k1-field.md)

--- a/knowledge/primitives/u4-pack.md
+++ b/knowledge/primitives/u4-pack.md
@@ -1,0 +1,41 @@
+# u4 pair-to-byte packing
+
+`arithmetic::u4::pack::pack_bytes` range-checks big-endian u4 pairs and packs
+each pair into a numeric ScriptNum value `16*high + low`. It is a numeric
+adapter for arithmetic and comparisons, not raw-byte concatenation: values
+128–255 use their minimally encoded multi-byte ScriptNum representation.
+
+## Contract
+
+```text
+high[0] low[0] ... high[n-1] low[n-1] -> byte[0] ... byte[n-1]
+```
+
+The last output is on top. All `2*n` input items are checked in `0..=15` and
+consumed. The script uses no hints, and all input data items coexist at entry.
+
+## Measurement
+
+The representative 32-byte fragment includes all 64 numeric range checks,
+four-addition-bit packing, output routing, and a complete 64-item empty-nibble
+witness. It excludes input serialization consumers and transaction context.
+
+| Configuration | Script | Witness | Data items | Hints | Peak | Static non-push opcodes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 32 packed numeric bytes | 1,003 bytes | 65 bytes | 64 | 0 (none) | 67 | 766 |
+
+The measured strict peak is well below the 1,000-item combined stack limit.
+The 766 non-push opcodes make the fragment tapscript-oriented rather than a
+legacy/P2SH/P2WSH policy target. Consensus and relay-policy validation remain
+unclassified.
+
+## Validation
+
+Focused tests cover every single-byte value, multi-byte output ordering,
+out-of-range input rejection, and zero-width generation:
+
+```sh
+cargo test --locked arithmetic::u4::pack
+cargo test --locked --test primitive_metrics u4_pack_metrics_are_current
+python3 tools/kb.py validate
+```

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -30,6 +30,7 @@ each input with the same output-restoration boundary.
 | Checked table batch, 32 nibbles | <!-- metric:u4_bits_checked_batch32 -->924<!-- /metric:u4_bits_checked_batch32 --> bytes | <!-- metric:u4_bits_checked_batch32_stack -->189<!-- /metric:u4_bits_checked_batch32_stack --> items | <!-- metric:u4_bits_checked_batch32_opcodes -->735<!-- /metric:u4_bits_checked_batch32_opcodes --> |
 | Unchecked table batch, 32 nibbles | <!-- metric:u4_bits_unchecked_batch32 -->764<!-- /metric:u4_bits_unchecked_batch32 --> bytes | 189 items | not recorded |
 | Existing branch splitter, 32 four-bit limbs | <!-- metric:u4_bits_branch_batch32 -->1374<!-- /metric:u4_bits_branch_batch32 --> bytes | <!-- metric:u4_bits_branch_batch32_stack -->130<!-- /metric:u4_bits_branch_batch32_stack --> items | not recorded |
+| `pack_bytes(32)` | <!-- metric:u4_pack_bytes_32 -->1003<!-- /metric:u4_pack_bytes_32 --> bytes | <!-- metric:u4_pack_bytes_32_stack -->67<!-- /metric:u4_pack_bytes_32_stack --> items | <!-- metric:u4_pack_bytes_32_opcodes -->766<!-- /metric:u4_pack_bytes_32_opcodes --> |
 
 The staggered table has 61 setup items and costs 31 bytes to remove. A checked
 query costs 22 bytes and restoring its four bits costs another four, so the
@@ -48,6 +49,9 @@ before using a value as an `OP_PICK` index. `check_inputs=false` must be used
 only when a surrounding fragment already established that range: an invalid
 index can otherwise address below the table. The numeric range check does not
 by itself prove a byte-unique ScriptNum encoding.
+
+`pack::pack_bytes(n)` range-checks and packs `2*n` nibbles into `n` numeric
+ScriptNum values. Its 32-byte representative witness is <!-- metric:u4_pack_bytes_32_witness -->65<!-- /metric:u4_pack_bytes_32_witness --> bytes across 64 data items and uses no hints. Outputs at or above 128 are numeric ScriptNum values, not raw one-byte stack elements.
 
 ## Script compatibility and standardness
 

--- a/src/arithmetic/u4/mod.rs
+++ b/src/arithmetic/u4/mod.rs
@@ -1,6 +1,7 @@
 pub mod add;
 pub mod bits;
 pub mod logic;
+pub mod pack;
 pub mod rotate;
 pub mod shift;
 pub mod stack;

--- a/src/arithmetic/u4/pack.rs
+++ b/src/arithmetic/u4/pack.rs
@@ -1,0 +1,84 @@
+//! Packing checked u4 pairs into numeric byte values.
+
+use crate::support::script::{script, Script};
+
+/// Pack `byte_count` big-endian u4 pairs into numeric byte values.
+///
+/// Stack before: `high[0] low[0] ... high[n-1] low[n-1]`.
+/// Stack after: `byte[0] ... byte[n-1]`, with the last byte on top. The
+/// outputs are ScriptNum integers in `0..=255`, not raw one-byte elements.
+pub fn pack_bytes(byte_count: u32) -> Script {
+    assert!(byte_count > 0, "byte count must be nonzero");
+    let nibble_count = byte_count * 2;
+
+    script! {
+        for index in 0..nibble_count {
+            { index }
+            OP_PICK
+            OP_DUP 0 OP_GREATERTHANOREQUAL OP_VERIFY
+            16 OP_LESSTHAN OP_VERIFY
+        }
+
+        for _ in 0..byte_count {
+            OP_SWAP
+            OP_DUP OP_ADD
+            OP_DUP OP_ADD
+            OP_DUP OP_ADD
+            OP_DUP OP_ADD
+            OP_ADD
+            OP_TOALTSTACK
+        }
+        for _ in 0..byte_count {
+            OP_FROMALTSTACK
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        arithmetic::u4::stack::u4_hex_to_nibbles,
+        support::{execution::execute_script, script::script},
+    };
+
+    #[test]
+    fn packs_all_single_bytes() {
+        for value in 0..=255u16 {
+            let hex = format!("{value:02x}");
+            let result = execute_script(script! {
+                { u4_hex_to_nibbles(&hex) }
+                { pack_bytes(1) }
+                { i64::from(value) } OP_EQUAL
+            });
+            assert!(result.success, "value={value:#04x}: {result}");
+        }
+    }
+
+    #[test]
+    fn packs_multiple_bytes_in_input_order() {
+        let result = execute_script(script! {
+            { u4_hex_to_nibbles("80ff01") }
+            { pack_bytes(3) }
+            1 OP_EQUALVERIFY
+            255 OP_EQUALVERIFY
+            128 OP_EQUAL
+        });
+        assert!(result.success, "{result}");
+    }
+
+    #[test]
+    fn rejects_an_out_of_range_nibble() {
+        let result = execute_script(script! {
+            0 16
+            { pack_bytes(1) }
+        });
+        assert!(!result.success);
+    }
+
+    #[test]
+    #[should_panic(expected = "byte count must be nonzero")]
+    fn rejects_zero_width() {
+        let _ = pack_bytes(0);
+    }
+}

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4037,6 +4037,41 @@ fn prince_metrics_are_current() {
     check_readme_metrics(prince_metrics());
 }
 
+#[test]
+fn u4_pack_metrics_are_current() {
+    let fragment = u4::pack::pack_bytes(32);
+    let witness = vec![Vec::new(); 64];
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_pack_bytes_32",
+            value: script_len(fragment.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_pack_bytes_32_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_pack_bytes_32_stack",
+            value: max_stack_items_strict(
+                script! {
+                    { fragment.clone() }
+                    for _ in 0..32 { OP_DROP }
+                    OP_1
+                },
+                witness,
+            ),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_pack_bytes_32_opcodes",
+            value: static_non_push_opcodes(fragment),
+        },
+    ]);
+}
+
 /// This isolated fixture exercises only the two small packed decoders. It
 /// stays runnable without enabling the ignored repository-wide metric suite.
 #[test]


### PR DESCRIPTION
## Summary
- add checked big-endian u4-pair packing into numeric ScriptNum byte values
- range-check hostile nibbles and preserve output order
- add exhaustive single-byte tests, multi-byte routing coverage, metrics, and documentation

## Validation
- `cargo test --locked arithmetic::u4::pack`
- `cargo test --locked --test primitive_metrics u4_pack_metrics_are_current`
- `python3 tools/kb.py validate`

The output is explicitly numeric ScriptNum data, not raw-byte concatenation; values 128 through 255 therefore use multi-byte ScriptNum encodings.
