### PR TITLE
feat(u4): add checked parity projection

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -199,6 +199,72 @@
       ]
     },
     {
+      "id": "arithmetic/u4-parity",
+      "name": "Checked u4 parity projection",
+      "class": "arithmetic/word",
+      "summary": "Range-checked batch projection from canonical u4 nibbles to numeric parity bits.",
+      "status": "active",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/u4-parity.md",
+      "implementation": "src/arithmetic/u4/parity.rs",
+      "documentation": "src/arithmetic/u4/README.md",
+      "tests": [
+        "src/arithmetic/u4/parity.rs",
+        "tests/primitive_metrics.rs"
+      ],
+      "references": [
+        "bitcoin-script-locked",
+        "bitcoin-scriptexec-locked"
+      ],
+      "techniques": [
+        "batch-lookup",
+        "digit-arithmetic",
+        "lookup-table"
+      ],
+      "security": "Every hostile input is range-checked before OP_PICK; the check proves numeric nibble range but not byte-unique ScriptNum encoding or a terminal predicate.",
+      "stack_contract": "Consumes preserved | nibble[0] ... nibble[n-1] and returns preserved | parity[0] ... parity[n-1], with the last item on top. The standalone batch keeps a 16-item lookup table resident.",
+      "configurations": [
+        {
+          "id": "checked-batch32",
+          "label": "u4_nibbles_to_parity(32)",
+          "parameters": {
+            "nibble_count": 32,
+            "table_items": 16,
+            "input_check": true,
+            "data_items": 32,
+            "hint_items": 0
+          },
+          "includes": "fragment-only: generated 16-item parity table, 32 range-checked queries, table cleanup, and output restoration; excludes input pushes, witness serialization from the script, terminal predicate, unrelated live state, and transaction context",
+          "script_bytes": 440,
+          "witness_bytes": 65,
+          "witness_bytes_max": 65,
+          "max_stack_items": 50,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": null,
+          "per_use_script_bytes": null,
+          "metric_keys": [
+            "u4_parity_batch32",
+            "u4_parity_batch32_witness",
+            "u4_parity_batch32_stack"
+          ]
+        }
+      ],
+      "limitations": [
+        "Numeric parity outputs are ScriptNum bits, not raw byte elements",
+        "Lookup table and outputs consume combined stack capacity",
+        "Static non-push opcode count is not an executed-opcode measurement",
+        "No Bitcoin Core consensus or relay-policy validation"
+      ],
+      "open_problems": [
+        "OP-001",
+        "OP-002",
+        "OP-003"
+      ]
+    },
+    {
       "id": "arithmetic/u32",
       "name": "u32 byte-word arithmetic",
       "class": "arithmetic/word",

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| 32 checked nibbles to parity bits | `u4_nibbles_to_parity(32)` | 440 | 50-item peak; one output bit per input |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -9,6 +9,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [ScriptNum constant multiplication](scriptnum-constant-mul.md)
 - [Hinted ScriptNum division](scriptnum-hinted-div.md)
 - [u4 digit arithmetic](u4.md)
+- [Checked u4 parity projection](u4-parity.md)
 - [u32 word arithmetic](u32.md)
 - [u31 prime-field arithmetic](u31.md)
 - [Native secp256k1 base-field arithmetic](secp256k1-field.md)

--- a/knowledge/primitives/u4-parity.md
+++ b/knowledge/primitives/u4-parity.md
@@ -1,0 +1,29 @@
+# Checked u4 parity projection
+
+`arithmetic::u4::parity::u4_nibbles_to_parity` consumes a contiguous batch of
+numeric nibbles, proves each value is in `0..=15`, and replaces it with one
+numeric parity bit. It uses a 16-item generated lookup table, so it is useful
+when a protocol needs parity but not the four expanded bits.
+
+- **Input:** `preserved | nibble[0] | ... | nibble[n-1]`, with the last nibble
+  on top.
+- **Output:** `preserved | parity[0] | ... | parity[n-1]`, with the last bit
+  on top.
+- **Evidence:** `locally-reproduced` by exhaustive nibble tests, malformed-input
+  tests, and a strict metric fixture.
+- **Representative result:** 440 locking-script bytes, 65 serialized witness
+  bytes for 32 one-byte data items, 50 combined stack items, and no hints for a
+  32-nibble batch. The fragment contains 328 static non-push opcodes; that is
+  not an executed-opcode or deployment claim.
+- **Execution class:** `unclassified`. The local strict executor runs the
+  fragment in tapscript context with the combined stack limit; no Bitcoin Core
+  consensus or relay-policy transaction has been tested.
+
+This is a projection fragment, not a complete locking script: callers still
+need a terminal predicate and any required clean-stack or encoding binding.
+The range check protects the lookup index but does not establish a byte-unique
+ScriptNum encoding.
+
+See the [implementation README](../../src/arithmetic/u4/README.md),
+[arithmetic comparison](../comparisons/arithmetic.md), and catalog record
+`arithmetic/u4-parity`.

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -12,6 +12,8 @@ these operations, but this module contains no hash-specific round logic.
   `1..=3` bit counts unless their function documents otherwise.
 - `bits::u4_nibbles_to_be_bits[_toaltstack](nibble_count, check_inputs)` takes
   an explicit batch size in `1..=234` and has no default for input checking.
+- `parity::u4_nibbles_to_parity(nibble_count)` takes a checked batch size in
+  `1..=982`.
 
 ## Script metrics
 
@@ -30,6 +32,9 @@ each input with the same output-restoration boundary.
 | Checked table batch, 32 nibbles | <!-- metric:u4_bits_checked_batch32 -->924<!-- /metric:u4_bits_checked_batch32 --> bytes | <!-- metric:u4_bits_checked_batch32_stack -->189<!-- /metric:u4_bits_checked_batch32_stack --> items | <!-- metric:u4_bits_checked_batch32_opcodes -->735<!-- /metric:u4_bits_checked_batch32_opcodes --> |
 | Unchecked table batch, 32 nibbles | <!-- metric:u4_bits_unchecked_batch32 -->764<!-- /metric:u4_bits_unchecked_batch32 --> bytes | 189 items | not recorded |
 | Existing branch splitter, 32 four-bit limbs | <!-- metric:u4_bits_branch_batch32 -->1374<!-- /metric:u4_bits_branch_batch32 --> bytes | <!-- metric:u4_bits_branch_batch32_stack -->130<!-- /metric:u4_bits_branch_batch32_stack --> items | not recorded |
+| Checked parity batch, 32 nibbles | <!-- metric:u4_parity_batch32 -->440<!-- /metric:u4_parity_batch32 --> bytes | <!-- metric:u4_parity_batch32_stack -->50<!-- /metric:u4_parity_batch32_stack --> items | <!-- metric:u4_parity_batch32_opcodes -->328<!-- /metric:u4_parity_batch32_opcodes --> |
+
+<!-- metric:u4_parity_batch32_witness -->65<!-- /metric:u4_parity_batch32_witness --> serialized witness bytes for the representative parity batch.
 
 The staggered table has 61 setup items and costs 31 bytes to remove. A checked
 query costs 22 bytes and restoring its four bits costs another four, so the
@@ -37,6 +42,11 @@ complete checked batch is `92 + 26*n` bytes. The existing branch splitter is
 `43*n` bytes on the same boundary; the checked table wins from six nibbles.
 Unchecked lookup is `92 + 21*n` and wins from five, but is safe only for
 previously certified nibbles.
+
+The parity table has 16 items. A checked 32-nibble batch is measured at 440
+bytes and 50 combined stack items, with no hints and 65 witness bytes across
+32 data items. It returns one numeric bit per nibble and is smaller than
+expanding each nibble to four bits when only parity is needed.
 
 ## Security
 
@@ -48,6 +58,9 @@ before using a value as an `OP_PICK` index. `check_inputs=false` must be used
 only when a surrounding fragment already established that range: an invalid
 index can otherwise address below the table. The numeric range check does not
 by itself prove a byte-unique ScriptNum encoding.
+
+Parity uses the same numeric range proof before its `OP_PICK` lookup. Its
+output is a ScriptNum bit, not a raw byte or a terminal truth value.
 
 ## Script compatibility and standardness
 
@@ -82,13 +95,20 @@ The standalone batch peak is `4*n + 61` combined main/alt-stack items. The
 generator rejects `n > 234`, but callers must reduce the batch further for any
 unrelated live state.
 
+For `u4_nibbles_to_parity(n)`, the same input ordering is consumed and replaced
+one-for-one by parity bits. The standalone peak is `n + 18` during range checks;
+the generator rejects `n > 982`, and callers must reduce the batch for unrelated
+live state.
+
 ## Operational notes
 
 `stack*.rs` contains adapters for `bitcoin-script-stack`; `add.rs`, `logic.rs`,
 `rotate.rs`, and `shift.rs` remain generic. `bits.rs` exhaustively tests every
 nibble in checked and unchecked mode, rejects malformed numeric inputs in
 checked mode, verifies multi-input ordering, and executes the maximum
-standalone batch under the strict local stack limit.
+standalone batch under the strict local stack limit. `parity.rs` exhaustively
+checks the 16-value lookup domain, rejects malformed inputs and invalid batch
+sizes, and measures a representative strict batch.
 
 The four-equal-index query is derived from the combined nibble-table sketch in
 [`coins/bitcoin-scripts`](https://github.com/coins/bitcoin-scripts/blob/8f442e4bf8a744dd9bf69b2937bdebcaed5cae77/split-into-bits.md).

--- a/src/arithmetic/u4/mod.rs
+++ b/src/arithmetic/u4/mod.rs
@@ -1,6 +1,7 @@
 pub mod add;
 pub mod bits;
 pub mod logic;
+pub mod parity;
 pub mod rotate;
 pub mod shift;
 pub mod stack;

--- a/src/arithmetic/u4/parity.rs
+++ b/src/arithmetic/u4/parity.rs
@@ -1,0 +1,105 @@
+//! Batched parity projection for canonical u4 limbs.
+
+use super::stack::u4_drop;
+use crate::support::script::*;
+
+/// Persistent items used by the nibble-parity lookup table.
+pub const U4_PARITY_TABLE_ITEMS: u32 = 16;
+
+/// Largest batch that fits the 1,000-item stack limit without unrelated state.
+/// Two temporary stack items are needed by each range check.
+pub const U4_PARITY_MAX_BATCH: u32 = 1_000 - U4_PARITY_TABLE_ITEMS - 2;
+
+fn parity(value: u32) -> u32 {
+    (value.count_ones() & 1) as u32
+}
+
+fn push_parity_table() -> Script {
+    script! {
+        for value in (0..U4_PARITY_TABLE_ITEMS).rev() {
+            { parity(value) }
+        }
+    }
+}
+
+/// Consume `nibble_count` canonical nibbles and replace each with its parity.
+///
+/// Before: `preserved | nibble[0] | ... | nibble[n-1]`, with `nibble[n-1]`
+/// on top. After: `preserved | parity[0] | ... | parity[n-1]`, with the last
+/// output on top. Every input is checked to be in `0..=15` before it indexes
+/// the table.
+pub fn u4_nibbles_to_parity(nibble_count: u32) -> Script {
+    assert!(nibble_count > 0, "nibble batch must not be empty");
+    assert!(
+        nibble_count <= U4_PARITY_MAX_BATCH,
+        "nibble-parity batch exceeds Bitcoin Script's stack limit"
+    );
+
+    script! {
+        { push_parity_table() }
+        for _ in 0..nibble_count {
+            { U4_PARITY_TABLE_ITEMS } OP_ROLL
+            OP_DUP OP_0 OP_GREATERTHANOREQUAL OP_VERIFY
+            OP_DUP OP_16 OP_LESSTHAN OP_VERIFY
+            OP_PICK OP_TOALTSTACK
+        }
+        { u4_drop(U4_PARITY_TABLE_ITEMS) }
+        for _ in 0..nibble_count {
+            OP_FROMALTSTACK
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        arithmetic::u4::stack::u4_hex_to_nibbles,
+        support::{execution::execute_script, script::script},
+    };
+
+    #[test]
+    fn projects_all_nibble_parities_in_order() {
+        let result = execute_script(script! {
+            { u4_hex_to_nibbles("0123456789abcdef") }
+            { u4_nibbles_to_parity(16) }
+            0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            0 OP_EQUAL
+        });
+        assert!(result.success, "parity projection failed: {result}");
+    }
+
+    #[test]
+    fn rejects_out_of_range_nibbles() {
+        for invalid in [-1, 16] {
+            let result = execute_script(script! {
+                { invalid }
+                { u4_nibbles_to_parity(1) }
+                OP_TRUE
+            });
+            assert!(!result.success, "accepted invalid nibble {invalid}");
+        }
+    }
+
+    #[test]
+    fn rejects_zero_and_overlarge_batches() {
+        assert!(std::panic::catch_unwind(|| u4_nibbles_to_parity(0)).is_err());
+        assert!(
+            std::panic::catch_unwind(|| { u4_nibbles_to_parity(U4_PARITY_MAX_BATCH + 1) }).is_err()
+        );
+    }
+}

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,48 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+/// This isolated fixture measures only the checked u4 parity projection.
+#[test]
+fn u4_parity_metrics_are_current() {
+    const NIBBLE_COUNT: u32 = 32;
+    let fragment = u4::parity::u4_nibbles_to_parity(NIBBLE_COUNT);
+    let witness = vec![scriptnum(15); NIBBLE_COUNT as usize];
+    let peak = max_stack_items_strict(
+        script! {
+            { fragment.clone() }
+            for _ in 0..NIBBLE_COUNT {
+                OP_DROP
+            }
+            OP_TRUE
+        },
+        witness.clone(),
+    );
+
+    assert_eq!(witness.len(), NIBBLE_COUNT as usize);
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_parity_batch32",
+            value: script_len(fragment.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_parity_batch32_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_parity_batch32_stack",
+            value: peak,
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_parity_batch32_opcodes",
+            value: static_non_push_opcodes(fragment),
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary

Add a checked u4 batch primitive that projects each canonical nibble to one numeric parity bit using a 16-item lookup table.

The fragment:
- rejects values outside 0..=15 before OP_PICK
- preserves documented input/output ordering
- rejects empty and stack-overlarge batches
- records 440 script bytes, 65 witness bytes across 32 data items, 50 strict stack items, and 328 static non-push opcodes

## Validation

- python3 tools/kb.py validate
- cargo test --locked arithmetic::u4::parity
- cargo test --locked --test primitive_metrics u4_parity_metrics_are_current
- git diff --check

Full-repository tests were intentionally not run.