### PR TITLE
feat(u32): add checked zero predicate

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -275,6 +275,71 @@
       ]
     },
     {
+      "id": "arithmetic/u32-zero",
+      "name": "Checked u32 zero predicate",
+      "class": "arithmetic/word",
+      "summary": "Range-checked zero predicate for a four-byte u32 word without lookup-table memory.",
+      "status": "active",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/u32-zero.md",
+      "implementation": "src/arithmetic/u32/zero.rs",
+      "documentation": "src/arithmetic/u32/README.md",
+      "tests": [
+        "src/arithmetic/u32/zero.rs",
+        "tests/primitive_metrics.rs"
+      ],
+      "references": [
+        "bitcoin-script-locked",
+        "bitcoin-scriptexec-locked"
+      ],
+      "techniques": [
+        "digit-arithmetic",
+        "range-check",
+        "stack-routing"
+      ],
+      "security": "Every hostile byte is range-checked before its zero predicate; the check proves numeric byte range but not byte-unique ScriptNum encoding or a terminal predicate.",
+      "stack_contract": "Consumes four byte-valued limbs in most-significant-byte-first order and replaces them with one numeric Boolean. No lookup table remains resident.",
+      "configurations": [
+        {
+          "id": "checked-word",
+          "label": "u32_iszero()",
+          "parameters": {
+            "byte_count": 4,
+            "input_check": true,
+            "data_items": 4,
+            "hint_items": 0
+          },
+          "includes": "fragment-only: four byte range checks, four zero predicates, Boolean accumulation, and no table memory; excludes input pushes, witness serialization from the script, terminal predicate, unrelated live state, and transaction context",
+          "script_bytes": 53,
+          "witness_bytes": 13,
+          "witness_bytes_max": 13,
+          "max_stack_items": 6,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 53,
+          "metric_keys": [
+            "u32_zero",
+            "u32_zero_witness",
+            "u32_zero_stack"
+          ]
+        }
+      ],
+      "limitations": [
+        "Numeric Boolean output is not a complete clean-stack script",
+        "Numeric range checks do not establish byte-unique ScriptNum encoding",
+        "Static non-push opcode count is not an executed-opcode measurement",
+        "No Bitcoin Core consensus or relay-policy validation"
+      ],
+      "open_problems": [
+        "OP-001",
+        "OP-002",
+        "OP-003"
+      ]
+    },
+    {
       "id": "arithmetic/u31",
       "name": "u31 prime-field arithmetic",
       "class": "arithmetic/field",

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Checked u32 zero predicate | `u32_iszero()` | 53 | 6-item peak; no lookup table |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -10,6 +10,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [Hinted ScriptNum division](scriptnum-hinted-div.md)
 - [u4 digit arithmetic](u4.md)
 - [u32 word arithmetic](u32.md)
+- [Checked u32 zero predicate](u32-zero.md)
 - [u31 prime-field arithmetic](u31.md)
 - [Native secp256k1 base-field arithmetic](secp256k1-field.md)
 - [Ed25519 base-field multiplication](ed25519-field.md)

--- a/knowledge/primitives/u32-zero.md
+++ b/knowledge/primitives/u32-zero.md
@@ -1,0 +1,26 @@
+# Checked u32 zero predicate
+
+`arithmetic::u32::zero::u32_iszero` consumes a u32 represented by four numeric
+byte limbs, checks each limb's byte range, and returns one numeric Boolean for
+whether the word is zero. It uses no lookup table.
+
+- **Input:** four byte-valued limbs, most significant byte first, with the
+  least significant byte on top.
+- **Output:** one numeric Boolean ScriptNum.
+- **Evidence:** `locally-reproduced` by zero, nonzero, boundary, and malformed
+  byte tests plus a strict metric fixture.
+- **Representative result:** 53 locking-script bytes, 13 serialized witness
+  bytes across four data items, 6 combined stack items, and no hints. The
+  fragment contains 37 static non-push opcodes; this is not an executed-opcode
+  or deployment claim.
+- **Execution class:** `unclassified`. The strict local executor uses a
+  tapscript context and the combined stack limit; Bitcoin Core consensus and
+  relay policy have not been differentially tested.
+
+This is a fragment rather than a complete locking script. Callers still need
+any terminal predicate, clean-stack rule, and byte-unique ScriptNum binding
+required by their protocol.
+
+See the [implementation README](../../src/arithmetic/u32/README.md),
+[arithmetic comparison](../comparisons/arithmetic.md), and catalog record
+`arithmetic/u32-zero`.

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -18,6 +18,8 @@ they do not use BN254 or any other field modulus.
 - `u32_or(a, b, stack_size)`, like XOR and AND, takes distinct word offsets.
   `stack_size` is one plus the number of u32 words above the shared byte-logic
   table. With exactly two working words, the usual value is `3`.
+- `zero::u32_iszero()` consumes one four-byte word, range-checks every byte,
+  and returns one numeric Boolean.
 - Stack helpers use whole-word offsets. Rotation helpers additionally take a
   rotation count. There are no implicit parameter defaults.
 
@@ -39,6 +41,7 @@ as less-than-or-equal.
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
+| `u32_iszero()` | <!-- metric:u32_zero -->53<!-- /metric:u32_zero --> bytes | <!-- metric:u32_zero_witness -->13<!-- /metric:u32_zero_witness --> bytes | <!-- metric:u32_zero_stack -->6<!-- /metric:u32_zero_stack --> items; <!-- metric:u32_zero_opcodes -->37<!-- /metric:u32_zero_opcodes --> static non-push opcodes |
 
 Operand witness serialization is deliberately excluded: callers may construct
 words inside the locking script or supply four witness items per word. No
@@ -50,6 +53,10 @@ of XOR, AND, and OR operations in one script.
 There is no independent cryptographic security parameter. Arithmetic is exact
 only for byte limbs in `0..=255`; callers accepting adversarial witness values
 must enforce limb range and canonical Script-number encoding where required.
+
+`u32_iszero` performs the byte range checks itself, then combines the four
+byte-wise zero predicates without a lookup table. It returns a numeric Boolean
+and does not provide a clean-stack or terminal-script wrapper.
 
 ## Script compatibility and standardness
 

--- a/src/arithmetic/u32/mod.rs
+++ b/src/arithmetic/u32/mod.rs
@@ -6,4 +6,5 @@ pub mod rotate;
 pub mod stack;
 pub mod sub;
 pub mod xor;
+pub mod zero;
 pub mod zip;

--- a/src/arithmetic/u32/zero.rs
+++ b/src/arithmetic/u32/zero.rs
@@ -1,0 +1,60 @@
+//! Checked zero predicate for a four-byte u32 word.
+
+use crate::support::script::*;
+
+/// Consume the top u32 word and return whether it is zero.
+///
+/// The input is four byte-valued limbs, most significant byte first. Each
+/// limb is checked in `0..=255` before its zero predicate is accumulated. The
+/// result is one numeric Boolean ScriptNum.
+pub fn u32_iszero() -> Script {
+    script! {
+        for _ in 0..4 {
+            OP_DUP OP_0 OP_GREATERTHANOREQUAL OP_VERIFY
+            OP_DUP 256 OP_LESSTHAN OP_VERIFY
+            OP_NOT OP_TOALTSTACK
+        }
+        OP_FROMALTSTACK
+        OP_FROMALTSTACK OP_BOOLAND
+        OP_FROMALTSTACK OP_BOOLAND
+        OP_FROMALTSTACK OP_BOOLAND
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        arithmetic::u32::stack::u32_push,
+        support::{execution::execute_script, script::script},
+    };
+
+    #[test]
+    fn recognizes_zero_and_nonzero_words() {
+        for (word, expected) in [
+            (0, true),
+            (1, false),
+            (0x8000_0000, false),
+            (u32::MAX, false),
+        ] {
+            let result = execute_script(script! {
+                { u32_push(word) }
+                { u32_iszero() }
+                { expected as u32 } OP_EQUAL
+            });
+            assert!(result.success, "word={word:#010x}: {result}");
+        }
+    }
+
+    #[test]
+    fn rejects_non_byte_limbs() {
+        for invalid in [-1, 256] {
+            let result = execute_script(script! {
+                0 0 0 { invalid }
+                { u32_iszero() }
+                OP_TRUE
+            });
+            assert!(!result.success, "accepted invalid byte {invalid}");
+        }
+    }
+}

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,45 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+/// This isolated fixture measures only the checked u32 zero predicate.
+#[test]
+fn u32_zero_metrics_are_current() {
+    let fragment = u32::zero::u32_iszero();
+    let witness = vec![scriptnum(255); 4];
+    let peak = max_stack_items_strict(
+        script! {
+            { fragment.clone() }
+            OP_DROP
+            OP_TRUE
+        },
+        witness.clone(),
+    );
+
+    assert_eq!(witness.len(), 4);
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_zero",
+            value: script_len(fragment.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_zero_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_zero_stack",
+            value: peak,
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_zero_opcodes",
+            value: static_non_push_opcodes(fragment),
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary

Add a checked u32 zero predicate that consumes four most-significant-byte-first byte limbs and returns one numeric Boolean without lookup-table memory.

The fragment:
- rejects values outside 0..=255 for every limb
- handles zero, nonzero, signed-boundary, and all-ones words
- records 53 script bytes, 13 witness bytes across four data items, 6 strict stack items, and 37 static non-push opcodes

## Validation

- python3 tools/kb.py validate
- cargo test --locked arithmetic::u32::zero
- cargo test --locked --test primitive_metrics u32_zero_metrics_are_current
- git diff --check

Full-repository tests were intentionally not run.