### PR TITLE
feat(u4): add checked LSB projection

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -199,6 +199,72 @@
       ]
     },
     {
+      "id": "arithmetic/u4-lsb",
+      "name": "Checked u4 least-significant-bit projection",
+      "class": "arithmetic/word",
+      "summary": "Range-checked batch projection from canonical u4 nibbles to their least-significant bits.",
+      "status": "active",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/u4-lsb.md",
+      "implementation": "src/arithmetic/u4/lsb.rs",
+      "documentation": "src/arithmetic/u4/README.md",
+      "tests": [
+        "src/arithmetic/u4/lsb.rs",
+        "tests/primitive_metrics.rs"
+      ],
+      "references": [
+        "bitcoin-script-locked",
+        "bitcoin-scriptexec-locked"
+      ],
+      "techniques": [
+        "batch-lookup",
+        "digit-arithmetic",
+        "lookup-table"
+      ],
+      "security": "Every hostile input is range-checked before OP_PICK; the check proves numeric nibble range but not byte-unique ScriptNum encoding or a terminal predicate.",
+      "stack_contract": "Consumes preserved | nibble[0] ... nibble[n-1] and returns preserved | lsb[0] ... lsb[n-1], with the last item on top. The standalone batch keeps a 16-item lookup table resident.",
+      "configurations": [
+        {
+          "id": "checked-batch32",
+          "label": "u4_nibbles_to_lsb(32)",
+          "parameters": {
+            "nibble_count": 32,
+            "table_items": 16,
+            "input_check": true,
+            "data_items": 32,
+            "hint_items": 0
+          },
+          "includes": "fragment-only: generated 16-item LSB table, 32 range-checked queries, table cleanup, and output restoration; excludes input pushes, witness serialization from the script, terminal predicate, unrelated live state, and transaction context",
+          "script_bytes": 440,
+          "witness_bytes": 65,
+          "witness_bytes_max": 65,
+          "max_stack_items": 50,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": null,
+          "per_use_script_bytes": null,
+          "metric_keys": [
+            "u4_lsb_batch32",
+            "u4_lsb_batch32_witness",
+            "u4_lsb_batch32_stack"
+          ]
+        }
+      ],
+      "limitations": [
+        "Numeric LSB outputs are ScriptNum bits, not raw byte elements",
+        "Lookup table and outputs consume combined stack capacity",
+        "Static non-push opcode count is not an executed-opcode measurement",
+        "No Bitcoin Core consensus or relay-policy validation"
+      ],
+      "open_problems": [
+        "OP-001",
+        "OP-002",
+        "OP-003"
+      ]
+    },
+    {
       "id": "arithmetic/u32",
       "name": "u32 byte-word arithmetic",
       "class": "arithmetic/word",

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| 32 checked nibbles to LSB bits | `u4_nibbles_to_lsb(32)` | 440 | 50-item peak; one output bit per input |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/index.md
+++ b/knowledge/primitives/index.md
@@ -9,6 +9,7 @@ the source. Read a page together with its comparison page and evidence record.
 - [ScriptNum constant multiplication](scriptnum-constant-mul.md)
 - [Hinted ScriptNum division](scriptnum-hinted-div.md)
 - [u4 digit arithmetic](u4.md)
+- [Checked u4 least-significant-bit projection](u4-lsb.md)
 - [u32 word arithmetic](u32.md)
 - [u31 prime-field arithmetic](u31.md)
 - [Native secp256k1 base-field arithmetic](secp256k1-field.md)

--- a/knowledge/primitives/u4-lsb.md
+++ b/knowledge/primitives/u4-lsb.md
@@ -1,0 +1,27 @@
+# Checked u4 least-significant-bit projection
+
+`arithmetic::u4::lsb::u4_nibbles_to_lsb` consumes a contiguous batch of
+canonical four-bit limbs, proves each value is in `0..=15`, and replaces it
+with its least-significant bit. It avoids materializing the other three bits
+when a bit-oriented encoding needs only the low bit.
+
+- **Input:** `preserved | nibble[0] | ... | nibble[n-1]`, with the last nibble
+  on top.
+- **Output:** `preserved | lsb[0] | ... | lsb[n-1]`, with the last bit on top.
+- **Evidence:** `locally-reproduced` by all-nibble ordering tests, malformed
+  input tests, batch-size boundary tests, and a strict metric fixture.
+- **Representative result:** 440 locking-script bytes, 65 serialized witness
+  bytes across 32 data items, 50 combined stack items, and no hints. The
+  fragment contains 328 static non-push opcodes; this is not an executed-opcode
+  or deployment claim.
+- **Execution class:** `unclassified`. The strict local executor uses a
+  tapscript context and the combined stack limit; Bitcoin Core consensus and
+  relay policy have not been differentially tested.
+
+This is a projection fragment, not a complete locking script. Callers still
+need any terminal predicate, clean-stack rule, and byte-unique ScriptNum
+binding required by their protocol.
+
+See the [implementation README](../../src/arithmetic/u4/README.md),
+[arithmetic comparison](../comparisons/arithmetic.md), and catalog record
+`arithmetic/u4-lsb`.

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -12,6 +12,8 @@ these operations, but this module contains no hash-specific round logic.
   `1..=3` bit counts unless their function documents otherwise.
 - `bits::u4_nibbles_to_be_bits[_toaltstack](nibble_count, check_inputs)` takes
   an explicit batch size in `1..=234` and has no default for input checking.
+- `lsb::u4_nibbles_to_lsb(nibble_count)` takes a checked batch size in
+  `1..=982` and returns one bit per input nibble.
 
 ## Script metrics
 
@@ -30,6 +32,9 @@ each input with the same output-restoration boundary.
 | Checked table batch, 32 nibbles | <!-- metric:u4_bits_checked_batch32 -->924<!-- /metric:u4_bits_checked_batch32 --> bytes | <!-- metric:u4_bits_checked_batch32_stack -->189<!-- /metric:u4_bits_checked_batch32_stack --> items | <!-- metric:u4_bits_checked_batch32_opcodes -->735<!-- /metric:u4_bits_checked_batch32_opcodes --> |
 | Unchecked table batch, 32 nibbles | <!-- metric:u4_bits_unchecked_batch32 -->764<!-- /metric:u4_bits_unchecked_batch32 --> bytes | 189 items | not recorded |
 | Existing branch splitter, 32 four-bit limbs | <!-- metric:u4_bits_branch_batch32 -->1374<!-- /metric:u4_bits_branch_batch32 --> bytes | <!-- metric:u4_bits_branch_batch32_stack -->130<!-- /metric:u4_bits_branch_batch32_stack --> items | not recorded |
+| Checked LSB batch, 32 nibbles | <!-- metric:u4_lsb_batch32 -->440<!-- /metric:u4_lsb_batch32 --> bytes | <!-- metric:u4_lsb_batch32_stack -->50<!-- /metric:u4_lsb_batch32_stack --> items | <!-- metric:u4_lsb_batch32_opcodes -->328<!-- /metric:u4_lsb_batch32_opcodes --> |
+
+<!-- metric:u4_lsb_batch32_witness -->65<!-- /metric:u4_lsb_batch32_witness --> serialized witness bytes for the representative LSB batch.
 
 The staggered table has 61 setup items and costs 31 bytes to remove. A checked
 query costs 22 bytes and restoring its four bits costs another four, so the

--- a/src/arithmetic/u4/lsb.rs
+++ b/src/arithmetic/u4/lsb.rs
@@ -1,0 +1,93 @@
+//! Batched least-significant-bit projection for canonical u4 limbs.
+
+use super::stack::u4_drop;
+use crate::support::script::*;
+
+/// Persistent items used by the nibble-LSB lookup table.
+pub const U4_LSB_TABLE_ITEMS: u32 = 16;
+
+/// Largest batch that fits the 1,000-item stack limit without unrelated state.
+pub const U4_LSB_MAX_BATCH: u32 = 1_000 - U4_LSB_TABLE_ITEMS - 2;
+
+fn push_lsb_table() -> Script {
+    script! {
+        for value in (0..U4_LSB_TABLE_ITEMS).rev() {
+            { value & 1 }
+        }
+    }
+}
+
+/// Consume canonical nibbles and replace each with its least-significant bit.
+///
+/// Before: `preserved | nibble[0] | ... | nibble[n-1]`, with the last nibble
+/// on top. After: `preserved | lsb[0] | ... | lsb[n-1]`, with the last output
+/// on top. Every input is range-checked before it indexes the table.
+pub fn u4_nibbles_to_lsb(nibble_count: u32) -> Script {
+    assert!(nibble_count > 0, "nibble batch must not be empty");
+    assert!(
+        nibble_count <= U4_LSB_MAX_BATCH,
+        "nibble-LSB batch exceeds Bitcoin Script's stack limit"
+    );
+
+    script! {
+        { push_lsb_table() }
+        for _ in 0..nibble_count {
+            { U4_LSB_TABLE_ITEMS } OP_ROLL
+            OP_DUP OP_0 OP_GREATERTHANOREQUAL OP_VERIFY
+            OP_DUP OP_16 OP_LESSTHAN OP_VERIFY
+            OP_PICK OP_TOALTSTACK
+        }
+        { u4_drop(U4_LSB_TABLE_ITEMS) }
+        for _ in 0..nibble_count {
+            OP_FROMALTSTACK
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        arithmetic::u4::stack::u4_hex_to_nibbles,
+        support::{execution::execute_script, script::script},
+    };
+
+    #[test]
+    fn projects_all_nibble_least_significant_bits_in_order() {
+        let result = execute_script(script! {
+            { u4_hex_to_nibbles("0123456789abcdef") }
+            { u4_nibbles_to_lsb(16) }
+            1 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            0 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            0 OP_EQUAL
+        });
+        assert!(result.success, "LSB projection failed: {result}");
+    }
+
+    #[test]
+    fn rejects_out_of_range_nibbles_and_batch_sizes() {
+        for invalid in [-1, 16] {
+            let result = execute_script(script! {
+                { invalid }
+                { u4_nibbles_to_lsb(1) }
+                OP_TRUE
+            });
+            assert!(!result.success, "accepted invalid nibble {invalid}");
+        }
+        assert!(std::panic::catch_unwind(|| u4_nibbles_to_lsb(0)).is_err());
+        assert!(std::panic::catch_unwind(|| { u4_nibbles_to_lsb(U4_LSB_MAX_BATCH + 1) }).is_err());
+    }
+}

--- a/src/arithmetic/u4/mod.rs
+++ b/src/arithmetic/u4/mod.rs
@@ -1,6 +1,7 @@
 pub mod add;
 pub mod bits;
 pub mod logic;
+pub mod lsb;
 pub mod rotate;
 pub mod shift;
 pub mod stack;

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,48 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+/// This isolated fixture measures only the checked u4 LSB projection.
+#[test]
+fn u4_lsb_metrics_are_current() {
+    const NIBBLE_COUNT: u32 = 32;
+    let fragment = u4::lsb::u4_nibbles_to_lsb(NIBBLE_COUNT);
+    let witness = vec![scriptnum(15); NIBBLE_COUNT as usize];
+    let peak = max_stack_items_strict(
+        script! {
+            { fragment.clone() }
+            for _ in 0..NIBBLE_COUNT {
+                OP_DROP
+            }
+            OP_TRUE
+        },
+        witness.clone(),
+    );
+
+    assert_eq!(witness.len(), NIBBLE_COUNT as usize);
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_lsb_batch32",
+            value: script_len(fragment.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_lsb_batch32_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_lsb_batch32_stack",
+            value: peak,
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_lsb_batch32_opcodes",
+            value: static_non_push_opcodes(fragment),
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary

Add a checked u4 batch primitive that projects each canonical nibble to its least-significant bit using a 16-item lookup table.

The fragment:
- rejects values outside 0..=15 before OP_PICK
- preserves documented input/output ordering
- rejects empty and stack-overlarge batches
- records 440 script bytes, 65 witness bytes across 32 data items, 50 strict stack items, and 328 static non-push opcodes

## Validation

- python3 tools/kb.py validate
- cargo test --locked arithmetic::u4::lsb
- cargo test --locked --test primitive_metrics u4_lsb_metrics_are_current
- git diff --check

Full-repository tests were intentionally not run.