### PR TITLE
feat(u32): add canonical compressed decoder

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -263,6 +263,29 @@
           "metric_keys": [
             "u8_logic_table_push"
           ]
+        },
+        {
+          "id": "uncompress-canonical",
+          "label": "Canonical compressed-u32 decoder",
+          "parameters": {
+            "raw_aliases": false,
+            "data_items": 1,
+            "hint_items": 0
+          },
+          "includes": "fragment-only: exact raw ScriptNum encoding check, canonical signed-u32 expansion, and four byte outputs; representative witness is canonical five-byte -2^31; excludes terminal predicate, input push, and transaction context",
+          "script_bytes": 431,
+          "witness_bytes": 7,
+          "witness_bytes_max": 7,
+          "max_stack_items": 7,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": null,
+          "metric_keys": [
+            "u32_uncompress_canonical",
+            "u32_uncompress_canonical_witness",
+            "u32_uncompress_canonical_stack"
+          ]
         }
       ],
       "limitations": [

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Canonical compressed-u32 decode | u32 raw-encoding boundary | 431 | 7-item peak; 7-byte maximum witness; rejects aliases |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -10,6 +10,8 @@ stack manipulation.
 - **Tradeoff:** operation fragments are moderate, while a reusable Boolean table
   occupies 256 stack items.
 - **Representative results:** add is 78 bytes; subtract is 77; less-than is 39.
+  The canonical compressed-u32 decoder is measured separately because it
+  authenticates the raw ScriptNum encoding before expanding four bytes.
 - **Consumers:** SHA-1, SHA-256, RIPEMD-160, and SHAKE256.
 
 See the [implementation README](../../src/arithmetic/u32/README.md),

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -20,6 +20,9 @@ they do not use BN254 or any other field modulus.
   table. With exactly two working words, the usual value is `3`.
 - Stack helpers use whole-word offsets. Rotation helpers additionally take a
   rotation count. There are no implicit parameter defaults.
+- `u32_uncompress_canonical()` consumes one minimally encoded signed ScriptNum
+  representing a u32 and returns its four MSB-first bytes. It rejects raw
+  aliases and accepts five bytes only for `-2^31`.
 
 ## Script metrics
 
@@ -39,11 +42,16 @@ as less-than-or-equal.
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
+| `u32_uncompress_canonical()` | <!-- metric:u32_uncompress_canonical -->431<!-- /metric:u32_uncompress_canonical --> bytes | <!-- metric:u32_uncompress_canonical_witness -->7<!-- /metric:u32_uncompress_canonical_witness --> bytes, 1 data item | <!-- metric:u32_uncompress_canonical_stack -->7<!-- /metric:u32_uncompress_canonical_stack --> items |
 
 Operand witness serialization is deliberately excluded: callers may construct
 words inside the locking script or supply four witness items per word. No
 operation-specific hint is needed. The logic table can be shared by any number
 of XOR, AND, and OR operations in one script.
+
+The canonical compressed-u32 row uses the maximum five-byte witness item for
+`-2^31`. It is a raw-encoding boundary: `u32_uncompress()` remains available
+for callers that intentionally accept ScriptNum aliases.
 
 ## Security
 

--- a/src/arithmetic/u32/stack.rs
+++ b/src/arithmetic/u32/stack.rs
@@ -154,10 +154,64 @@ pub fn u32_uncompress() -> Script {
     }
 }
 
+/// Decode one minimally encoded signed ScriptNum representing a u32.
+///
+/// The high bit selects the signed two's-complement half of the u32 domain;
+/// `0x80000000` is the sole accepted five-byte encoding. The four output
+/// bytes retain the module's most-significant-byte-first order.
+pub fn u32_uncompress_canonical() -> Script {
+    script! {
+        OP_SIZE 5 OP_NUMEQUAL
+        OP_IF
+            OP_DUP { -2_147_483_648i64 } OP_EQUALVERIFY
+        OP_ELSE
+            OP_DUP OP_DUP 0 OP_ADD OP_EQUALVERIFY
+        OP_ENDIF
+        { u32_uncompress() }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::support::execution::run;
+    use crate::support::execution::{execute_raw_script_with_inputs_strict, run};
+
+    fn scriptnum(value: i64) -> Vec<u8> {
+        let mut bytes = [0u8; 8];
+        let length = bitcoin::script::write_scriptint(&mut bytes, value);
+        bytes[..length].to_vec()
+    }
+
+    fn accepts_canonical(value: u32) {
+        let script = script! {
+            { u32_uncompress_canonical() }
+            { u32_push(value) }
+            { u32_equalverify() }
+            OP_TRUE
+        };
+        let result = execute_raw_script_with_inputs_strict(
+            script.compile_with_policy().to_bytes(),
+            vec![scriptnum(i64::from(value as i32))],
+        );
+        assert!(
+            result.success,
+            "failed to decode canonical {value:#x}: {result}"
+        );
+    }
+
+    fn rejects_noncanonical(raw: Vec<u8>) {
+        let script = script! {
+            { u32_uncompress_canonical() }
+            OP_2DROP
+            OP_2DROP
+            OP_TRUE
+        };
+        let result = execute_raw_script_with_inputs_strict(
+            script.compile_with_policy().to_bytes(),
+            vec![raw],
+        );
+        assert!(!result.success, "accepted noncanonical compressed word");
+    }
 
     #[test]
     fn test_u32_notequal() {
@@ -177,5 +231,20 @@ mod tests {
             };
             run(script);
         }
+    }
+
+    #[test]
+    fn canonical_uncompress_accepts_signed_boundaries() {
+        for value in [0, 127, 128, 0x7fff_ffff, 0x8000_0000, u32::MAX] {
+            accepts_canonical(value);
+        }
+    }
+
+    #[test]
+    fn canonical_uncompress_rejects_raw_aliases_and_out_of_domain_words() {
+        rejects_noncanonical(vec![0x01, 0x00]);
+        rejects_noncanonical(vec![0x80]);
+        rejects_noncanonical(vec![0x01, 0x00, 0x00, 0x00, 0x80]);
+        rejects_noncanonical(vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x80]);
     }
 }

--- a/src/fields/ed25519/u5_packed.rs
+++ b/src/fields/ed25519/u5_packed.rs
@@ -9,7 +9,7 @@
 //!
 //! Both decoders treat every input as hostile. The low-stack decoder rejects
 //! alternate raw ScriptNum encodings and expands exact words through
-//! [`u32_uncompress`]. The faster decoder maps signed words directly to bits;
+//! [`u32_uncompress_canonical`]. The faster decoder maps signed words directly to bits;
 //! it allows at-most-four-byte aliases when execution flags do, without
 //! changing the decoded value. Both reconstruct all 255 payload bits, reject
 //! the padding bit, and reject the centered backend's 19-value canonical gap.
@@ -24,7 +24,7 @@ use num_bigint::BigUint;
 use crate::{
     arithmetic::{
         u31::{u31_to_bits_with_width, U31_LOOKUP_STACK_LIMIT},
-        u32::stack::{u32_compress, u32_uncompress},
+        u32::stack::{u32_compress, u32_uncompress_canonical},
     },
     fields::ed25519::u5_balanced_table::{self, FieldDigits, FIELD_DIGIT_COUNT},
     support::script::*,
@@ -203,28 +203,11 @@ fn byte_to_radix32_stream(carry_bits: usize) -> Script {
     }
 }
 
-// Keep one word only if its byte string is the unique canonical compressed-u32
-// representation. Adding zero cheaply normalizes every at-most-four-byte
-// ScriptNum; raw equality then detects negative zero, redundant sign bytes,
-// and other aliases even when MINIMALDATA is disabled. The only valid
-// five-byte compressed word is canonical -2^31 and is checked directly.
-fn certify_exact_compressed_word() -> Script {
-    script! {
-        OP_SIZE 5 OP_NUMEQUAL
-        OP_IF
-            OP_DUP { -2_147_483_648i64 } OP_EQUALVERIFY
-        OP_ELSE
-            OP_DUP OP_DUP 0 OP_ADD OP_EQUALVERIFY
-        OP_ENDIF
-    }
-}
-
 // Decode one exact top compressed word to four certified bytes.
 fn exact_uncompress_word(keep_original: bool) -> Script {
     script! {
         if keep_original { OP_DUP }
-        { certify_exact_compressed_word() }
-        { u32_uncompress() }
+        { u32_uncompress_canonical() }
     }
 }
 

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,39 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+#[test]
+fn u32_uncompress_canonical_metrics_are_current() {
+    let fragment = u32::stack::u32_uncompress_canonical();
+    let witness = vec![scriptnum(i64::from(i32::MIN))];
+    let stack = max_stack_items_strict(
+        script! {
+            { fragment.clone() }
+            OP_2DROP
+            OP_2DROP
+            OP_1
+        },
+        witness.clone(),
+    );
+
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_uncompress_canonical",
+            value: script_len(fragment.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_uncompress_canonical_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_uncompress_canonical_stack",
+            value: stack,
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary

- add `u32_uncompress_canonical()` for the exact raw ScriptNum encoding of a compressed u32
- reject negative zero, redundant sign bytes, nonminimal aliases, and out-of-domain five-byte values
- reuse the shared boundary in the Ed25519 packed decoder instead of keeping a duplicate validator
- document the contract and measured cost

## Evidence

- evidence: locally-reproduced
- execution class: unclassified; local tapscript helper only, with no Bitcoin Core differential validation
- representative maximum item: canonical five-byte `-2^31`
- measured fragment: 431 locking-script bytes, 7-byte serialized witness, 7-item strict combined peak

## Validation

- `cargo fmt -- --check`
- `python3 tools/kb.py validate`
- `cargo test --locked arithmetic::u32::stack`
- `cargo test --locked fields::ed25519::u5_packed`
- `cargo test --locked --test primitive_metrics u32_uncompress_canonical_metrics_are_current`

The full repository test suite was intentionally not run; this contribution is covered by focused tests for the new boundary and its affected packed decoder.
