### PR TITLE
feat(u31): add checked bit decomposition

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -337,6 +337,29 @@
           "metric_keys": [
             "qm31_mul"
           ]
+        },
+        {
+          "id": "checked-bits-width9",
+          "label": "Checked u31 9-bit decomposition",
+          "parameters": {
+            "bit_width": 9,
+            "maximum_value": 511,
+            "hint_items": 0
+          },
+          "includes": "fragment-only: nonnegative and upper-bound checks followed by nine-bit decomposition; representative witness is one two-byte ScriptNum; excludes terminal predicate and input/output checks",
+          "script_bytes": 85,
+          "witness_bytes": 4,
+          "witness_bytes_max": 4,
+          "max_stack_items": 10,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 85,
+          "metric_keys": [
+            "u31_bits_checked_width9",
+            "u31_bits_checked_width9_witness",
+            "u31_bits_checked_width9_stack"
+          ]
         }
       ],
       "limitations": [

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Checked u31 width-9 decomposition | u31 range boundary | 85 | 10-item peak; 4-byte representative witness; numeric `0..=511` check |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/u31.md
+++ b/knowledge/primitives/u31.md
@@ -11,6 +11,9 @@ two-bit windows or specialized compact, constant, and lookup strategies.
   hostile coefficients.
 - **Representative results:** M31 add 18 bytes, subtract 12, multiplication
   1,370; degree-four QM31 multiplication 12,901.
+- **Boundary adapter:** checked width-9 bit decomposition is measured
+  separately from the unchecked field backend because it enforces the numeric
+  input range.
 - **Alternatives:** lookup-based F257/F12289 paths when the field and reuse
   pattern justify table memory.
 

--- a/src/arithmetic/u31/README.md
+++ b/src/arithmetic/u31/README.md
@@ -24,6 +24,18 @@ the upstream MIT notice is preserved in [`LICENSE`](LICENSE).
   query; callers must also count unrelated state below the table.
 - Generators reject layouts that intrinsically exceed 1,000 combined stack
   items. This does not replace composition-level accounting.
+- `u31_to_bits_with_width_checked(bit_width)` enforces a nonnegative value
+  below `2^bit_width` before decomposition. The unchecked form remains useful
+  when a surrounding field invariant already supplies that proof.
+
+## Bit decomposition metrics
+
+The checked width-9 row includes one representative two-byte ScriptNum witness,
+the nine output bits, and no auxiliary hints.
+
+| Fragment | Locking script | Serialized witness | Maximum combined stack |
+| --- | ---: | ---: | ---: |
+| `u31_to_bits_with_width_checked(9)` | <!-- metric:u31_bits_checked_width9 -->85<!-- /metric:u31_bits_checked_width9 --> bytes | <!-- metric:u31_bits_checked_width9_witness -->4<!-- /metric:u31_bits_checked_width9_witness --> bytes, 1 data item | <!-- metric:u31_bits_checked_width9_stack -->10<!-- /metric:u31_bits_checked_width9_stack --> items |
 
 ## Validity and deployment
 

--- a/src/arithmetic/u31/mod.rs
+++ b/src/arithmetic/u31/mod.rs
@@ -190,6 +190,35 @@ pub fn u31_to_bits_with_width(bit_width: u32) -> Script {
     }
 }
 
+/// Decompose a numerically range-checked value into exactly `bit_width` bits.
+///
+/// This checks the positive ScriptNum domain before calling
+/// [`u31_to_bits_with_width`]. It does not enforce byte-minimal witness
+/// encoding; use a raw-encoding boundary when that distinction matters.
+pub fn u31_to_bits_with_width_checked(bit_width: u32) -> Script {
+    assert!(
+        (1..=31).contains(&bit_width),
+        "u31 bit width must be in 1..=31"
+    );
+
+    let upper_bound = if bit_width == 31 {
+        script! {
+            OP_DUP 0 OP_GREATERTHANOREQUAL OP_VERIFY
+            OP_DUP { 0x7fff_ffffu32 } OP_LESSTHANOREQUAL OP_VERIFY
+        }
+    } else {
+        script! {
+            OP_DUP 0 OP_GREATERTHANOREQUAL OP_VERIFY
+            OP_DUP { 1u32 << bit_width } OP_LESSTHAN OP_VERIFY
+        }
+    };
+
+    script! {
+        { upper_bound }
+        { u31_to_bits_with_width(bit_width) }
+    }
+}
+
 fn u31_mul_common_with_window_pairs<C: U31Config>(window_pairs: u32) -> Script {
     script! {
         0
@@ -599,6 +628,43 @@ mod tests {
                 OP_TRUE
             });
             assert!(result.success, "9-bit decomposition failed: {result}");
+        }
+    }
+
+    #[test]
+    fn checked_bit_decomposition_enforces_width() {
+        for (value, width) in [
+            (0, 9),
+            (1, 9),
+            (255, 9),
+            (256, 9),
+            (511, 9),
+            (i32::MAX as u32, 31),
+        ] {
+            let bits = (0..width).map(|i| (value >> i) & 1).collect::<Vec<_>>();
+            let result = execute_script(script! {
+                { value }
+                { u31_to_bits_with_width_checked(width) }
+                for bit in bits {
+                    { bit }
+                    OP_EQUALVERIFY
+                }
+                OP_TRUE
+            });
+            assert!(
+                result.success,
+                "checked decomposition failed for {value}: {result}"
+            );
+        }
+
+        for (value, width) in [(-1, 9), (512, 9), (i32::MIN, 31)] {
+            let result = execute_script(script! {
+                { value }
+                { u31_to_bits_with_width_checked(width) }
+                for _ in 0..width { OP_DROP }
+                OP_TRUE
+            });
+            assert!(!result.success, "accepted out-of-range value {value}");
         }
     }
 

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,38 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+#[test]
+fn u31_checked_bits_metrics_are_current() {
+    let fragment = u31::u31_to_bits_with_width_checked(9);
+    let witness = vec![scriptnum(511)];
+    let stack = max_stack_items_strict(
+        script! {
+            { fragment.clone() }
+            for _ in 0..9 { OP_DROP }
+            OP_1
+        },
+        witness.clone(),
+    );
+
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u31/README.md",
+            key: "u31_bits_checked_width9",
+            value: script_len(fragment),
+        },
+        Metric {
+            readme: "src/arithmetic/u31/README.md",
+            key: "u31_bits_checked_width9_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u31/README.md",
+            key: "u31_bits_checked_width9_stack",
+            value: stack,
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary

- add `u31_to_bits_with_width_checked(bit_width)` with explicit numeric range enforcement
- handle the width-31 boundary without attempting to push `2^31` as a positive ScriptNum
- cover zero, width boundaries, negative inputs, and upper-bound rejection
- document and measure the checked adapter

## Evidence

- evidence: locally-reproduced
- execution class: unclassified; local tapscript helper only, with no Bitcoin Core differential validation
- representative width-9 fragment: 85 locking-script bytes, 4-byte serialized witness, 10-item strict combined peak
- the wrapper checks numeric range, not byte-minimal witness encoding; callers needing raw-byte canonicality must use a separate encoding boundary

## Validation

- `cargo fmt -- --check`
- `python3 tools/kb.py validate`
- `cargo test --locked arithmetic::u31`
- `cargo test --locked --test primitive_metrics u31_checked_bits_metrics_are_current`

The full repository test suite was intentionally not run; the u31 module and isolated metric test provide the scoped validation.
