### PR TITLE
feat(scriptint): add canonical encoding check

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -60,6 +60,61 @@
       ]
     },
     {
+      "id": "arithmetic/scriptnum-canonical",
+      "name": "Canonical ScriptNum boundary",
+      "class": "arithmetic/scriptnum",
+      "summary": "Raw-byte canonicality check for one minimally encoded at-most-four-byte ScriptNum.",
+      "status": "active",
+      "evidence": "locally-reproduced",
+      "execution": "unclassified",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/scriptnum-canonical.md",
+      "implementation": "src/arithmetic/scriptint/mod.rs",
+      "documentation": "src/arithmetic/scriptint/README.md",
+      "tests": [
+        "arithmetic::scriptint::tests::verifies_canonical_scriptnum_encoding",
+        "arithmetic::scriptint::tests::rejects_scriptnum_aliases_and_oversized_items"
+      ],
+      "references": [
+        "bitcoin-script-locked",
+        "bitcoin-scriptexec-locked"
+      ],
+      "techniques": [
+        "scriptnum-canonicality"
+      ],
+      "security": "Rejects raw aliases but does not impose a protocol-specific numeric range or terminal predicate.",
+      "stack_contract": "... item -> ... item, preserving the minimally encoded at-most-four-byte ScriptNum.",
+      "configurations": [
+        {
+          "id": "verify-canonical",
+          "label": "scriptint::verify_canonical()",
+          "parameters": {
+            "maximum_item_bytes": 4,
+            "hint_items": 0
+          },
+          "includes": "fragment-only: raw size bound and reserialization equality check; representative witness is one canonical four-byte ScriptNum; excludes numeric range checks, terminal predicate, and transaction context",
+          "script_bytes": 5,
+          "witness_bytes": 6,
+          "witness_bytes_max": 6,
+          "max_stack_items": 4,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 5,
+          "metric_keys": [
+            "scriptint_verify_canonical",
+            "scriptint_verify_canonical_witness",
+            "scriptint_verify_canonical_stack"
+          ]
+        }
+      ],
+      "limitations": [
+        "Four-byte ScriptNum range",
+        "Not validated against Bitcoin Core"
+      ],
+      "open_problems": []
+    },
+    {
       "id": "arithmetic/scriptnum-hinted-div",
       "name": "Hinted ScriptNum division",
       "class": "arithmetic/scriptnum",

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -6,6 +6,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Need | Local construction | Representative script bytes | Main constraint |
 | --- | --- | ---: | --- |
 | Small constant product | ScriptNum × 13 | 10 | Four-byte ScriptNum domain |
+| Canonical ScriptNum boundary | `scriptint::verify_canonical()` | 5 | 4-item peak; rejects raw aliases and oversized items |
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |

--- a/knowledge/primitives/scriptnum-canonical.md
+++ b/knowledge/primitives/scriptnum-canonical.md
@@ -1,0 +1,17 @@
+# Canonical ScriptNum boundary
+
+`scriptint::verify_canonical()` preserves one top-stack ScriptNum only when
+its raw item is the unique minimal encoding of an at-most-four-byte value. It
+rejects negative zero, redundant sign bytes, and items longer than four bytes.
+
+- **Evidence:** locally reproduced with boundary and malformed-encoding tests.
+- **Deployment:** unclassified; the fragment is exercised by the repository's
+  local tapscript helper, not differentially validated against Bitcoin Core.
+- **Cost:** 5 bytes, one representative 4-byte witness item, and a 4-item
+  combined peak.
+- **Scope:** this is raw encoding canonicality, not a numeric range check or a
+  complete locking script. A caller still needs its own terminal predicate and
+  any protocol-specific value bounds.
+
+See the [implementation README](../../src/arithmetic/scriptint/README.md)
+and the `arithmetic/scriptnum-canonical` catalog record.

--- a/src/arithmetic/scriptint/README.md
+++ b/src/arithmetic/scriptint/README.md
@@ -16,6 +16,8 @@ or `OP_MUL` opcodes.
 - `hinted_div_rem` returns quotient and remainder.
 - `hinted_div` returns only the quotient.
 - `hinted_rem` returns only the remainder.
+- `verify_canonical` preserves one minimally encoded at-most-four-byte
+  ScriptNum and rejects aliases, negative zero, and oversized items.
 - `dividend` and `quotient_hint` are minimally encoded, at-most-four-byte
   Script integers supplied on the stack. Their product and every intermediate
   arithmetic value must also fit the four-byte Script-number domain.
@@ -31,6 +33,7 @@ witness encoding. Maximum stack items count the combined main and alt stacks.
 | `hinted_div_rem(8)` | <!-- metric:scriptint_div_rem_8 -->13<!-- /metric:scriptint_div_rem_8 --> bytes | <!-- metric:scriptint_div_witness_min -->3<!-- /metric:scriptint_div_witness_min -->–<!-- metric:scriptint_div_witness_max -->11<!-- /metric:scriptint_div_witness_max --> bytes | <!-- metric:scriptint_div_rem_stack -->5<!-- /metric:scriptint_div_rem_stack --> |
 | `hinted_div(8)` | <!-- metric:scriptint_div_8 -->14<!-- /metric:scriptint_div_8 --> bytes | same | same or lower |
 | `hinted_rem(8)` | <!-- metric:scriptint_rem_8 -->14<!-- /metric:scriptint_rem_8 --> bytes | same | same or lower |
+| `verify_canonical()` | <!-- metric:scriptint_verify_canonical -->5<!-- /metric:scriptint_verify_canonical --> bytes | <!-- metric:scriptint_verify_canonical_witness -->6<!-- /metric:scriptint_verify_canonical_witness --> bytes (one 4-byte item) | <!-- metric:scriptint_verify_canonical_stack -->4<!-- /metric:scriptint_verify_canonical_stack --> |
 
 ## Security
 

--- a/src/arithmetic/scriptint/mod.rs
+++ b/src/arithmetic/scriptint/mod.rs
@@ -5,6 +5,14 @@ use crate::support::script::{script, Script};
 /// Largest positive integer accepted by four-byte Script-number arithmetic.
 pub const MAX_SCRIPTNUM: u32 = 0x7fff_ffff;
 
+/// Verify that the top stack item is a minimally encoded at-most-four-byte
+/// ScriptNum and leave it unchanged.
+pub fn verify_canonical() -> Script {
+    script! {
+        OP_DUP OP_DUP 0 OP_ADD OP_EQUALVERIFY
+    }
+}
+
 /// Multiply the top Script integer by the compile-time constant `multiplier`.
 ///
 /// Stack before: `... value`.
@@ -85,7 +93,16 @@ pub fn hinted_rem(divisor: u32) -> Script {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::support::{execution::execute_script, script::script};
+    use crate::support::{
+        execution::{execute_raw_script_with_inputs_strict, execute_script},
+        script::{script, ScriptCompilation},
+    };
+
+    fn scriptnum(value: i64) -> Vec<u8> {
+        let mut bytes = [0u8; 8];
+        let length = bitcoin::script::write_scriptint(&mut bytes, value);
+        bytes[..length].to_vec()
+    }
 
     fn assert_division(dividend: i64, divisor: u32) {
         let divisor_i64 = i64::from(divisor);
@@ -177,5 +194,49 @@ mod tests {
     #[should_panic(expected = "divisor must be in 1..=2147483647")]
     fn rejects_divisor_outside_scriptnum_domain() {
         let _ = hinted_div_rem(0x8000_0000);
+    }
+
+    #[test]
+    fn verifies_canonical_scriptnum_encoding() {
+        for value in [-1i64, 0, 1, 127, 128, 2_147_483_647] {
+            let result = execute_raw_script_with_inputs_strict(
+                script! {
+                    { verify_canonical() }
+                    OP_DROP
+                    OP_TRUE
+                }
+                .compile_with_policy()
+                .to_bytes(),
+                vec![scriptnum(value)],
+            );
+            assert!(
+                result.success,
+                "rejected canonical ScriptNum {value}: {result}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_scriptnum_aliases_and_oversized_items() {
+        use crate::support::execution::execute_raw_script_with_inputs_strict;
+
+        for raw in [
+            vec![0x01, 0x00],
+            vec![0x80],
+            vec![0x01, 0x80],
+            vec![0x00, 0x00, 0x00, 0x00, 0x00],
+        ] {
+            let result = execute_raw_script_with_inputs_strict(
+                script! {
+                    { verify_canonical() }
+                    OP_DROP
+                    OP_TRUE
+                }
+                .compile_with_policy()
+                .to_bytes(),
+                vec![raw],
+            );
+            assert!(!result.success, "accepted noncanonical ScriptNum");
+        }
     }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,36 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+#[test]
+fn scriptint_canonical_metrics_are_current() {
+    let fragment = scriptint::verify_canonical();
+    let witness = vec![scriptnum(2_147_483_647)];
+    let stack = max_stack_items(
+        script! {
+            { fragment.clone() }
+            OP_DROP OP_TRUE
+        },
+        witness.clone(),
+    );
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/scriptint/README.md",
+            key: "scriptint_verify_canonical",
+            value: script_len(fragment),
+        },
+        Metric {
+            readme: "src/arithmetic/scriptint/README.md",
+            key: "scriptint_verify_canonical_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/scriptint/README.md",
+            key: "scriptint_verify_canonical_stack",
+            value: stack,
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary

- add `scriptint::verify_canonical()` for minimally encoded at-most-four-byte ScriptNums
- reject negative zero, redundant sign bytes, and oversized items while preserving the value
- add boundary and malformed raw-witness tests
- document the reusable boundary and measured cost in the knowledge catalog

## Evidence

- evidence: locally-reproduced
- execution class: unclassified; local tapscript helper only, with no Bitcoin Core differential validation
- measured fragment: 5 locking-script bytes, 6-byte representative serialized witness, 4-item combined peak
- this is raw encoding canonicality only; protocol-specific numeric bounds and terminal predicates remain caller responsibilities

## Validation

- `cargo fmt -- --check`
- `python3 tools/kb.py validate`
- `cargo test --locked arithmetic::scriptint`
- `cargo test --locked --test primitive_metrics scriptint_canonical_metrics_are_current`

The full repository test suite was intentionally not run; the focused scriptint and metric tests cover this contribution.
