### PR TITLE
feat(u4): add nibble pair byte packing

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -185,6 +185,28 @@
             "u4_bits_checked_batch32_stack",
             "u4_bits_checked_batch32_opcodes"
           ]
+        },
+        {
+          "id": "nibble-pair-to-byte-checked",
+          "label": "Checked u4 high/low nibble pair to byte",
+          "parameters": {
+            "check_inputs": true,
+            "data_items": 2,
+            "hint_items": 0
+          },
+          "includes": "fragment-only: two nibble range checks and arithmetic packing of high | low into one byte; representative witness has two data items; excludes terminal predicate and transaction context",
+          "script_bytes": 20,
+          "witness_bytes": 4,
+          "witness_bytes_max": 4,
+          "max_stack_items": 5,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 20,
+          "metric_keys": [
+            "u4_pair_to_u8_checked",
+            "u4_pair_to_u8_checked_stack"
+          ]
         }
       ],
       "limitations": [

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Checked u4 nibble pair to byte | `u4_pair_to_u8(true)` | 20 | 5-item peak; 2 data items; 4-byte witness |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/u4.md
+++ b/knowledge/primitives/u4.md
@@ -17,6 +17,9 @@ variants. It is a backend for bit-oriented hashes and block ciphers.
 - **Input boundary:** the checked decomposition proves numeric range `0..=15`;
   unchecked lookup requires previously certified nibbles and neither form alone
   proves byte-unique ScriptNum encoding.
+- **Representation bridge:** checked high/low nibble packing provides a small
+  runtime path back to byte-oriented consumers; it is measured separately from
+  the table-backed bit decomposition.
 - **Consumers:** u4 SHA-256, AES-128, and PRINCEv2.
 
 See the [implementation README](../../src/arithmetic/u4/README.md) and catalog

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -30,6 +30,7 @@ each input with the same output-restoration boundary.
 | Checked table batch, 32 nibbles | <!-- metric:u4_bits_checked_batch32 -->924<!-- /metric:u4_bits_checked_batch32 --> bytes | <!-- metric:u4_bits_checked_batch32_stack -->189<!-- /metric:u4_bits_checked_batch32_stack --> items | <!-- metric:u4_bits_checked_batch32_opcodes -->735<!-- /metric:u4_bits_checked_batch32_opcodes --> |
 | Unchecked table batch, 32 nibbles | <!-- metric:u4_bits_unchecked_batch32 -->764<!-- /metric:u4_bits_unchecked_batch32 --> bytes | 189 items | not recorded |
 | Existing branch splitter, 32 four-bit limbs | <!-- metric:u4_bits_branch_batch32 -->1374<!-- /metric:u4_bits_branch_batch32 --> bytes | <!-- metric:u4_bits_branch_batch32_stack -->130<!-- /metric:u4_bits_branch_batch32_stack --> items | not recorded |
+| Checked high/low nibble pair to one byte | <!-- metric:u4_pair_to_u8_checked -->20<!-- /metric:u4_pair_to_u8_checked --> bytes | 4 bytes, 2 data items | <!-- metric:u4_pair_to_u8_checked_stack -->5<!-- /metric:u4_pair_to_u8_checked_stack --> items |
 
 The staggered table has 61 setup items and costs 31 bytes to remove. A checked
 query costs 22 bytes and restoring its four bits costs another four, so the
@@ -37,6 +38,11 @@ complete checked batch is `92 + 26*n` bytes. The existing branch splitter is
 `43*n` bytes on the same boundary; the checked table wins from six nibbles.
 Unchecked lookup is `92 + 21*n` and wins from five, but is safe only for
 previously certified nibbles.
+
+`u4_pair_to_u8(check_inputs)` is the small runtime bridge from nibble-oriented
+state to byte-oriented state. It consumes `high | low` and returns
+`16*high + low`; checked mode enforces both nibble ranges, while unchecked mode
+requires that invariant from the caller.
 
 ## Security
 

--- a/src/arithmetic/u4/stack.rs
+++ b/src/arithmetic/u4/stack.rs
@@ -91,6 +91,25 @@ pub fn u4_hex_to_nibbles(hex_str: &str) -> Script {
     }
 }
 
+/// Pack `high | low` nibbles into one byte-valued ScriptNum.
+///
+/// With `check_inputs`, both inputs are constrained to `0..=15`. Without it,
+/// the caller must already have established that invariant.
+pub fn u4_pair_to_u8(check_inputs: bool) -> Script {
+    script! {
+        if check_inputs {
+            OP_DUP 0 16 OP_WITHIN OP_VERIFY
+            1 OP_PICK 0 16 OP_WITHIN OP_VERIFY
+        }
+        OP_SWAP
+        OP_DUP OP_ADD
+        OP_DUP OP_ADD
+        OP_DUP OP_ADD
+        OP_DUP OP_ADD
+        OP_ADD
+    }
+}
+
 pub fn u4_repeat_number(n: u32, count: u32) -> Script {
     match count {
         0 => script! {},
@@ -200,5 +219,57 @@ mod tests {
             OP_TRUE
         };
         crate::support::execution::run(script);
+    }
+
+    #[test]
+    fn packs_all_checked_nibble_pairs() {
+        for byte in 0..=u8::MAX {
+            let result = crate::support::execution::execute_script(script! {
+                { (byte >> 4) as u32 }
+                { (byte & 0x0f) as u32 }
+                { u4_pair_to_u8(true) }
+                { byte as u32 } OP_EQUAL
+            });
+            assert!(result.success, "failed to pack byte {byte:#x}: {result}");
+        }
+    }
+
+    #[test]
+    fn checked_pair_rejects_malformed_nibbles_and_preserves_state() {
+        for (high, low) in [(-1, 0), (0, 16), (16, 0), (0, -1)] {
+            let result = crate::support::execution::execute_script(script! {
+                { high }
+                { low }
+                { u4_pair_to_u8(true) }
+                OP_TRUE
+            });
+            assert!(!result.success, "accepted malformed pair {high}, {low}");
+        }
+
+        let result = crate::support::execution::execute_script(script! {
+            OP_9
+            0xa
+            0xb
+            { u4_pair_to_u8(true) }
+            171 OP_EQUALVERIFY
+            9 OP_EQUAL
+        });
+        assert!(
+            result.success,
+            "pair packing changed preserved state: {result}"
+        );
+    }
+
+    #[test]
+    fn unchecked_pair_requires_the_caller_invariant() {
+        let result = crate::support::execution::execute_script(script! {
+            0 -1
+            { u4_pair_to_u8(false) }
+            -1 OP_EQUAL
+        });
+        assert!(
+            result.success,
+            "unchecked pair did not preserve hostile item: {result}"
+        );
     }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,32 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+#[test]
+fn u4_pair_to_u8_metrics_are_current() {
+    let fragment = u4::stack::u4_pair_to_u8(true);
+    let witness = vec![scriptnum(15), scriptnum(15)];
+    let stack = max_stack_items_strict(
+        script! {
+            { fragment.clone() }
+            OP_DROP
+            OP_1
+        },
+        witness.clone(),
+    );
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_pair_to_u8_checked",
+            value: script_len(fragment),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_pair_to_u8_checked_stack",
+            value: stack,
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary

- add `u4_pair_to_u8(check_inputs)` to pack `high | low` nibbles into one byte-valued ScriptNum
- checked mode validates both hostile inputs in `0..=15`; unchecked mode is explicit about its caller invariant
- add exhaustive 256-value coverage, malformed-input rejection, state preservation, and unchecked behavior tests
- document the u4-to-byte composition boundary and measured cost

## Evidence

- evidence: locally-reproduced
- execution class: unclassified; local tapscript helper only, with no Bitcoin Core differential validation
- representative checked fragment: 20 locking-script bytes, 4-byte serialized witness with 2 data items, 5-item strict combined peak, zero hints
- executed-opcode count is not recorded for this configuration

## Validation

- `cargo fmt -- --check`
- `python3 tools/kb.py validate`
- `cargo test --locked arithmetic::u4`
- `cargo test --locked --test primitive_metrics u4_pair_to_u8_metrics_are_current`

The full repository test suite was intentionally not run; the focused u4 module and metric test cover this contribution.
