### PR TITLE
feat(u4): add checked byte splitter

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -185,6 +185,29 @@
             "u4_bits_checked_batch32_stack",
             "u4_bits_checked_batch32_opcodes"
           ]
+        },
+        {
+          "id": "byte-to-nibble-pair-checked",
+          "label": "Checked u8 byte to high/low u4 pair",
+          "parameters": {
+            "check_inputs": true,
+            "data_items": 1,
+            "hint_items": 0
+          },
+          "includes": "fragment-only: byte range check, four threshold decisions, and high/low nibble restoration; representative witness has one two-byte ScriptNum; excludes terminal predicate and transaction context",
+          "script_bytes": 62,
+          "witness_bytes": 4,
+          "witness_bytes_max": 4,
+          "max_stack_items": 4,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 62,
+          "metric_keys": [
+            "u8_to_u4_pair_checked",
+            "u8_to_u4_pair_checked_witness",
+            "u8_to_u4_pair_checked_stack"
+          ]
         }
       ],
       "limitations": [

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Checked u8 byte to nibble pair | `u8_to_u4_pair(true)` | 62 | 4-item peak; 4-byte witness; two nibble outputs |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/u4.md
+++ b/knowledge/primitives/u4.md
@@ -17,6 +17,8 @@ variants. It is a backend for bit-oriented hashes and block ciphers.
 - **Input boundary:** the checked decomposition proves numeric range `0..=15`;
   unchecked lookup requires previously certified nibbles and neither form alone
   proves byte-unique ScriptNum encoding.
+- **Representation bridge:** the checked byte splitter uses a four-threshold
+  schedule to return high/low nibbles without the 61-item bit-table setup.
 - **Consumers:** u4 SHA-256, AES-128, and PRINCEv2.
 
 See the [implementation README](../../src/arithmetic/u4/README.md) and catalog

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -30,6 +30,7 @@ each input with the same output-restoration boundary.
 | Checked table batch, 32 nibbles | <!-- metric:u4_bits_checked_batch32 -->924<!-- /metric:u4_bits_checked_batch32 --> bytes | <!-- metric:u4_bits_checked_batch32_stack -->189<!-- /metric:u4_bits_checked_batch32_stack --> items | <!-- metric:u4_bits_checked_batch32_opcodes -->735<!-- /metric:u4_bits_checked_batch32_opcodes --> |
 | Unchecked table batch, 32 nibbles | <!-- metric:u4_bits_unchecked_batch32 -->764<!-- /metric:u4_bits_unchecked_batch32 --> bytes | 189 items | not recorded |
 | Existing branch splitter, 32 four-bit limbs | <!-- metric:u4_bits_branch_batch32 -->1374<!-- /metric:u4_bits_branch_batch32 --> bytes | <!-- metric:u4_bits_branch_batch32_stack -->130<!-- /metric:u4_bits_branch_batch32_stack --> items | not recorded |
+| Checked byte to high/low nibble pair | <!-- metric:u8_to_u4_pair_checked -->62<!-- /metric:u8_to_u4_pair_checked --> bytes | <!-- metric:u8_to_u4_pair_checked_witness -->4<!-- /metric:u8_to_u4_pair_checked_witness --> bytes, 1 data item | <!-- metric:u8_to_u4_pair_checked_stack -->4<!-- /metric:u8_to_u4_pair_checked_stack --> items |
 
 The staggered table has 61 setup items and costs 31 bytes to remove. A checked
 query costs 22 bytes and restoring its four bits costs another four, so the
@@ -37,6 +38,11 @@ complete checked batch is `92 + 26*n` bytes. The existing branch splitter is
 `43*n` bytes on the same boundary; the checked table wins from six nibbles.
 Unchecked lookup is `92 + 21*n` and wins from five, but is safe only for
 previously certified nibbles.
+
+`u8_to_u4_pair(check_inputs)` is the inverse bridge from byte-oriented state
+to high/low nibble state. Checked mode enforces `0..=255`; its four-threshold
+schedule preserves unrelated altstack state. Unchecked mode requires the byte
+invariant from the caller.
 
 ## Security
 

--- a/src/arithmetic/u4/stack.rs
+++ b/src/arithmetic/u4/stack.rs
@@ -91,6 +91,28 @@ pub fn u4_hex_to_nibbles(hex_str: &str) -> Script {
     }
 }
 
+/// Split one byte-valued ScriptNum into `high | low` nibbles.
+///
+/// With `check_inputs`, the byte is constrained to `0..=255`. Without it,
+/// the caller must already have established that invariant.
+pub fn u8_to_u4_pair(check_inputs: bool) -> Script {
+    script! {
+        if check_inputs {
+            OP_DUP 0 256 OP_WITHIN OP_VERIFY
+        }
+        0 OP_TOALTSTACK
+        for (threshold, nibble) in [(128, 8), (64, 4), (32, 2), (16, 1)] {
+            OP_DUP { threshold } OP_GREATERTHANOREQUAL
+            OP_IF
+                { threshold } OP_SUB
+                OP_FROMALTSTACK { nibble } OP_ADD OP_TOALTSTACK
+            OP_ENDIF
+        }
+        OP_FROMALTSTACK
+        OP_SWAP
+    }
+}
+
 pub fn u4_repeat_number(n: u32, count: u32) -> Script {
     match count {
         0 => script! {},
@@ -200,5 +222,57 @@ mod tests {
             OP_TRUE
         };
         crate::support::execution::run(script);
+    }
+
+    #[test]
+    fn splits_all_checked_bytes() {
+        for byte in 0..=u8::MAX {
+            let result = crate::support::execution::execute_script(script! {
+                { byte as u32 }
+                { u8_to_u4_pair(true) }
+                { (byte & 0x0f) as u32 } OP_EQUALVERIFY
+                { (byte >> 4) as u32 } OP_EQUAL
+            });
+            assert!(result.success, "failed to split byte {byte:#x}: {result}");
+        }
+    }
+
+    #[test]
+    fn checked_split_rejects_malformed_bytes_and_preserves_altstack() {
+        for invalid in [-1, 256] {
+            let result = crate::support::execution::execute_script(script! {
+                { invalid }
+                { u8_to_u4_pair(true) }
+                OP_TRUE
+            });
+            assert!(!result.success, "accepted malformed byte {invalid}");
+        }
+
+        let result = crate::support::execution::execute_script(script! {
+            OP_7 OP_TOALTSTACK
+            171
+            { u8_to_u4_pair(true) }
+            11 OP_EQUALVERIFY
+            10 OP_EQUALVERIFY
+            OP_FROMALTSTACK 7 OP_EQUAL
+        });
+        assert!(
+            result.success,
+            "split changed unrelated altstack state: {result}"
+        );
+    }
+
+    #[test]
+    fn unchecked_split_requires_the_caller_invariant() {
+        let result = crate::support::execution::execute_script(script! {
+            -1
+            { u8_to_u4_pair(false) }
+            -1 OP_EQUALVERIFY
+            0 OP_EQUAL
+        });
+        assert!(
+            result.success,
+            "unchecked split changed hostile byte: {result}"
+        );
     }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,37 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+#[test]
+fn u8_to_u4_pair_metrics_are_current() {
+    let fragment = u4::stack::u8_to_u4_pair(true);
+    let witness = vec![scriptnum(255)];
+    let stack = max_stack_items_strict(
+        script! {
+            { fragment.clone() }
+            OP_2DROP
+            OP_1
+        },
+        witness.clone(),
+    );
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u8_to_u4_pair_checked",
+            value: script_len(fragment),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u8_to_u4_pair_checked_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u8_to_u4_pair_checked_stack",
+            value: stack,
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary

- add `u8_to_u4_pair(check_inputs)` to split one byte-valued ScriptNum into high and low nibbles
- use a four-threshold schedule with no lookup-table memory and preserve unrelated altstack state
- checked mode validates `0..=255`; unchecked mode has an explicit caller invariant
- add exhaustive byte coverage, malformed-input rejection, state-preservation, and unchecked-hostile tests

## Evidence

- evidence: locally-reproduced
- execution class: unclassified; local tapscript helper only, with no Bitcoin Core differential validation
- representative checked fragment: 62 locking-script bytes, 4-byte serialized witness with 1 data item, 4-item strict combined peak, zero hints
- executed-opcode count is not recorded for this configuration

## Validation

- `cargo fmt -- --check`
- `python3 tools/kb.py validate`
- `cargo test --locked arithmetic::u4`
- `cargo test --locked --test primitive_metrics u8_to_u4_pair_metrics_are_current`

The full repository test suite was intentionally not run; the focused u4 module and metric test cover this contribution.
