### PR TITLE
feat(u32): add checked high-bit extraction

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -263,6 +263,28 @@
           "metric_keys": [
             "u8_logic_table_push"
           ]
+        },
+        {
+          "id": "checked-high-bit-extraction",
+          "label": "Checked u8 high-bit extraction",
+          "parameters": {
+            "hbit": 4,
+            "input_range": "0..=255"
+          },
+          "includes": "fragment-only: byte range check and high-bit extraction; excludes input push and output check",
+          "script_bytes": 73,
+          "witness_bytes": 4,
+          "witness_bytes_max": 4,
+          "max_stack_items": 5,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 73,
+          "metric_keys": [
+            "u8_extract_hbit_checked",
+            "u8_extract_hbit_checked_witness",
+            "u8_extract_hbit_checked_stack"
+          ]
         }
       ],
       "limitations": [

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Checked u8 high-bit extraction | `u8_extract_hbit_checked(4)` | 73 | 5-item peak; 4-byte witness; rejects non-byte ScriptNums |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -9,7 +9,8 @@ stack manipulation.
 - **Evidence:** locally reproduced, including exhaustive byte-level logic tests.
 - **Tradeoff:** operation fragments are moderate, while a reusable Boolean table
   occupies 256 stack items.
-- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39.
+- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39;
+  checked four-bit extraction is 73 bytes.
 - **Consumers:** SHA-1, SHA-256, RIPEMD-160, and SHAKE256.
 
 See the [implementation README](../../src/arithmetic/u32/README.md),

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -39,6 +39,7 @@ as less-than-or-equal.
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
+| `u8_extract_hbit_checked(4)` | <!-- metric:u8_extract_hbit_checked -->73<!-- /metric:u8_extract_hbit_checked --> bytes | <!-- metric:u8_extract_hbit_checked_witness -->4<!-- /metric:u8_extract_hbit_checked_witness --> bytes, 1 data item | <!-- metric:u8_extract_hbit_checked_stack -->5<!-- /metric:u8_extract_hbit_checked_stack --> items |
 
 Operand witness serialization is deliberately excluded: callers may construct
 words inside the locking script or supply four witness items per word. No

--- a/src/arithmetic/u32/rotate.rs
+++ b/src/arithmetic/u32/rotate.rs
@@ -133,6 +133,14 @@ pub fn u8_extract_hbit(hbit: usize) -> Script {
         OP_FROMALTSTACK
     }
 }
+
+/// Checked form of [`u8_extract_hbit`].
+pub fn u8_extract_hbit_checked(hbit: usize) -> Script {
+    script! {
+        OP_DUP 0 256 OP_WITHIN OP_VERIFY
+        { u8_extract_hbit(hbit) }
+    }
+}
 /// Reorders (reverse and rotate) the bytes of an u32 number, assuming the starting order is 1 2 3 4 (4 being at the top):
 /// if offset is 0, then reorder is 4 3 2 1
 /// if offset is 1, then reorder is 1 4 3 2
@@ -264,6 +272,28 @@ mod tests {
                     OP_EQUAL
                 };
                 run(script);
+            }
+        }
+    }
+
+    #[test]
+    fn test_checked_extract_hbit_rejects_non_bytes() {
+        for h in [1, 4, 7] {
+            for x in 0..=255 {
+                let result = crate::support::execution::execute_script(script! {
+                    { x }
+                    { u8_extract_hbit_checked(h) }
+                    { x >> (8 - h) } OP_EQUALVERIFY
+                    { (x << h) % 256 } OP_EQUAL
+                });
+                assert!(result.success, "failed for x={x}, h={h}: {result}");
+            }
+            for x in [-1, 256, 512] {
+                let result = crate::support::execution::execute_script(script! {
+                    { x }
+                    { u8_extract_hbit_checked(h) }
+                });
+                assert!(!result.success, "accepted non-byte x={x}, h={h}");
             }
         }
     }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,37 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+#[test]
+fn u8_extract_hbit_checked_metrics_are_current() {
+    let fragment = u32::rotate::u8_extract_hbit_checked(4);
+    let witness = vec![scriptnum(255)];
+    let stack = max_stack_items_strict(
+        script! {
+            { fragment.clone() }
+            OP_2DROP
+            OP_1
+        },
+        witness.clone(),
+    );
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u8_extract_hbit_checked",
+            value: script_len(fragment),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u8_extract_hbit_checked_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u8_extract_hbit_checked_stack",
+            value: stack,
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary
- add a checked wrapper for `u8_extract_hbit`
- reject negative and out-of-range ScriptNums before bit extraction
- document and catalog the 73-byte representative configuration

## Validation
- `cargo test --locked arithmetic::u32::rotate::tests::test_checked_extract_hbit_rejects_non_bytes`
- `cargo test --locked --test primitive_metrics u8_extract_hbit_checked_metrics_are_current`
- `python3 tools/kb.py validate`
- `cargo fmt --all -- --check`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the new primitive.