### PR TITLE
feat(u32): document stack-preserving word pick

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -263,6 +263,28 @@
           "metric_keys": [
             "u8_logic_table_push"
           ]
+        },
+        {
+          "id": "pick-depth-2",
+          "label": "Stack-preserving u32 copy at depth two",
+          "parameters": {
+            "word_depth": 2,
+            "word_items": 4
+          },
+          "includes": "fragment-only: four OP_PICK copies of one u32 word; excludes input pushes and output checks",
+          "script_bytes": 8,
+          "witness_bytes": 24,
+          "witness_bytes_max": 24,
+          "max_stack_items": 16,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 8,
+          "metric_keys": [
+            "u32_pick_2",
+            "u32_pick_2_witness",
+            "u32_pick_2_stack"
+          ]
         }
       ],
       "limitations": [

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Stack-preserving u32 copy | `u32_pick(2)` | 8 | 16-item peak; 24-byte witness; copies a word at depth two |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -9,7 +9,8 @@ stack manipulation.
 - **Evidence:** locally reproduced, including exhaustive byte-level logic tests.
 - **Tradeoff:** operation fragments are moderate, while a reusable Boolean table
   occupies 256 stack items.
-- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39.
+- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39;
+  `u32_pick(2)` is a stack-preserving word copy.
 - **Consumers:** SHA-1, SHA-256, RIPEMD-160, and SHAKE256.
 
 See the [implementation README](../../src/arithmetic/u32/README.md),

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -39,6 +39,7 @@ as less-than-or-equal.
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
+| `u32_pick(2)` | <!-- metric:u32_pick_2 -->8<!-- /metric:u32_pick_2 --> bytes | <!-- metric:u32_pick_2_witness -->24<!-- /metric:u32_pick_2_witness --> bytes, 12 data items | <!-- metric:u32_pick_2_stack -->16<!-- /metric:u32_pick_2_stack --> items |
 
 Operand witness serialization is deliberately excluded: callers may construct
 words inside the locking script or supply four witness items per word. No

--- a/src/arithmetic/u32/stack.rs
+++ b/src/arithmetic/u32/stack.rs
@@ -178,4 +178,21 @@ mod tests {
             run(script);
         }
     }
+
+    #[test]
+    fn test_u32_pick_preserves_words() {
+        let words = [0x0102_0304, 0xa0b0_c0d0, 0x1122_3344];
+        let script = script! {
+            { u32_push(words[0]) }
+            { u32_push(words[1]) }
+            { u32_push(words[2]) }
+            { u32_pick(2) }
+            { u32_push(words[0]) } { u32_equal() } OP_VERIFY
+            { u32_push(words[2]) } { u32_equal() } OP_VERIFY
+            { u32_push(words[1]) } { u32_equal() } OP_VERIFY
+            { u32_push(words[0]) } { u32_equal() } OP_VERIFY
+            OP_1
+        };
+        run(script);
+    }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,37 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+#[test]
+fn u32_pick_metrics_are_current() {
+    let fragment = u32::stack::u32_pick(2);
+    let witness = (0..12).map(scriptnum).collect::<Vec<_>>();
+    let stack = max_stack_items_strict(
+        script! {
+            { fragment.clone() }
+            for _ in 0..8 { OP_2DROP }
+            OP_1
+        },
+        witness.clone(),
+    );
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_pick_2",
+            value: script_len(fragment),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_pick_2_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_pick_2_stack",
+            value: stack,
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary
- add focused correctness coverage for `u32_pick(2)`
- document its stack-preserving copy contract
- record the representative 8-byte script, 24-byte witness, and 16-item peak

## Validation
- `cargo test --locked arithmetic::u32::stack::tests::test_u32_pick_preserves_words`
- `cargo test --locked --test primitive_metrics u32_pick_metrics_are_current`
- `python3 tools/kb.py validate`
- `cargo fmt --all -- --check`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the documented router.