### PR TITLE
feat(u4): document stack-preserving word copy

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -185,6 +185,28 @@
             "u4_bits_checked_batch32_stack",
             "u4_bits_checked_batch32_opcodes"
           ]
+        },
+        {
+          "id": "copy-u32-from-depth-0",
+          "label": "Stack-preserving eight-nibble u32 copy",
+          "parameters": {
+            "nibble_count": 8,
+            "address": 0
+          },
+          "includes": "fragment-only: eight OP_PICK copies of a contiguous u32 nibble group; excludes input pushes and output checks",
+          "script_bytes": 16,
+          "witness_bytes": 16,
+          "witness_bytes_max": 16,
+          "max_stack_items": 16,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 16,
+          "metric_keys": [
+            "u4_copy_u32_from_0",
+            "u4_copy_u32_from_0_witness",
+            "u4_copy_u32_from_0_stack"
+          ]
         }
       ],
       "limitations": [

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Stack-preserving u32 copy in nibble layout | `u4_copy_u32_from(0)` | 16 | 16-item peak; 16-byte witness; copies eight nibbles |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/u4.md
+++ b/knowledge/primitives/u4.md
@@ -11,7 +11,8 @@ variants. It is a backend for bit-oriented hashes and block ciphers.
 - **Representative results:** addition-table setup is 92 script bytes. A
   checked 32-nibble decomposition is 924 bytes, executes 735 non-push opcodes,
   and peaks at 189 combined stack items; the equal-boundary branch baseline is
-  1,374 bytes and peaks at 130.
+  1,374 bytes and peaks at 130. The stack-preserving eight-nibble copy helper
+  is measured separately in the implementation README.
 - **Composition constraint:** table memory and digit-expanded state can dominate
   the 1,000-item stack limit.
 - **Input boundary:** the checked decomposition proves numeric range `0..=15`;

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -30,6 +30,7 @@ each input with the same output-restoration boundary.
 | Checked table batch, 32 nibbles | <!-- metric:u4_bits_checked_batch32 -->924<!-- /metric:u4_bits_checked_batch32 --> bytes | <!-- metric:u4_bits_checked_batch32_stack -->189<!-- /metric:u4_bits_checked_batch32_stack --> items | <!-- metric:u4_bits_checked_batch32_opcodes -->735<!-- /metric:u4_bits_checked_batch32_opcodes --> |
 | Unchecked table batch, 32 nibbles | <!-- metric:u4_bits_unchecked_batch32 -->764<!-- /metric:u4_bits_unchecked_batch32 --> bytes | 189 items | not recorded |
 | Existing branch splitter, 32 four-bit limbs | <!-- metric:u4_bits_branch_batch32 -->1374<!-- /metric:u4_bits_branch_batch32 --> bytes | <!-- metric:u4_bits_branch_batch32_stack -->130<!-- /metric:u4_bits_branch_batch32_stack --> items | not recorded |
+| `u4_copy_u32_from(0)` | <!-- metric:u4_copy_u32_from_0 -->16<!-- /metric:u4_copy_u32_from_0 --> bytes | <!-- metric:u4_copy_u32_from_0_witness -->16<!-- /metric:u4_copy_u32_from_0_witness --> bytes, 8 data items | <!-- metric:u4_copy_u32_from_0_stack -->16<!-- /metric:u4_copy_u32_from_0_stack --> items |
 
 The staggered table has 61 setup items and costs 31 bytes to remove. A checked
 query costs 22 bytes and restoring its four bits costs another four, so the

--- a/src/arithmetic/u4/stack.rs
+++ b/src/arithmetic/u4/stack.rs
@@ -201,4 +201,20 @@ mod tests {
         };
         crate::support::execution::run(script);
     }
+
+    #[test]
+    fn copy_u32_from_preserves_the_source_and_unrelated_state() {
+        let script = script! {
+            5 OP_TOALTSTACK
+            99
+            { u4_number_to_nibble(0x12345678) }
+            { u4_copy_u32_from(0) }
+            { u4_number_to_nibble(0x12345678) }
+            { verify_n(8) }
+            { u4_drop(8) }
+            OP_FROMALTSTACK 5 OP_EQUALVERIFY
+            99 OP_EQUAL
+        };
+        crate::support::execution::run(script);
+    }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,37 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+#[test]
+fn u4_copy_u32_from_metrics_are_current() {
+    let fragment = u4::stack::u4_copy_u32_from(0);
+    let witness = (0..8).map(scriptnum).collect::<Vec<_>>();
+    let stack = max_stack_items_strict(
+        script! {
+            { fragment.clone() }
+            for _ in 0..8 { OP_2DROP }
+            OP_1
+        },
+        witness.clone(),
+    );
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_copy_u32_from_0",
+            value: script_len(fragment),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_copy_u32_from_0_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_copy_u32_from_0_stack",
+            value: stack,
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary
- add a focused contract test for `u4_copy_u32_from(0)`
- verify source, unrelated main-stack state, and altstack state are preserved
- record the representative 16-byte script, 16-byte witness, and 16-item peak

## Validation
- `cargo test --locked arithmetic::u4::stack::tests::copy_u32_from_preserves_the_source_and_unrelated_state`
- `cargo test --locked --test primitive_metrics u4_copy_u32_from_metrics_are_current`
- `python3 tools/kb.py validate`
- `cargo fmt --all -- --check`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the documented router.