### PR TITLE
feat(u4): add canonical nibble boundary

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -185,6 +185,28 @@
             "u4_bits_checked_batch32_stack",
             "u4_bits_checked_batch32_opcodes"
           ]
+        },
+        {
+          "id": "canonical-nibble-boundary",
+          "label": "Canonical checked ScriptNum nibble",
+          "parameters": {
+            "range": "0..=15",
+            "encoding": "minimal at-most-four-byte ScriptNum"
+          },
+          "includes": "fragment-only: numeric nibble range and raw ScriptNum canonicality checks; preserves the value and excludes input push and output check",
+          "script_bytes": 10,
+          "witness_bytes": 3,
+          "witness_bytes_max": 3,
+          "max_stack_items": 4,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 10,
+          "metric_keys": [
+            "u4_canonical_nibble",
+            "u4_canonical_nibble_witness",
+            "u4_canonical_nibble_stack"
+          ]
         }
       ],
       "limitations": [

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Canonical checked nibble boundary | `verify_canonical_nibble()` | 10 | 4-item peak; 3-byte witness; rejects noncanonical ScriptNums |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/u4.md
+++ b/knowledge/primitives/u4.md
@@ -16,7 +16,8 @@ variants. It is a backend for bit-oriented hashes and block ciphers.
   the 1,000-item stack limit.
 - **Input boundary:** the checked decomposition proves numeric range `0..=15`;
   unchecked lookup requires previously certified nibbles and neither form alone
-  proves byte-unique ScriptNum encoding.
+  proves byte-unique ScriptNum encoding. `verify_canonical_nibble()` combines
+  the range and raw ScriptNum canonicality checks for hostile witness items.
 - **Consumers:** u4 SHA-256, AES-128, and PRINCEv2.
 
 See the [implementation README](../../src/arithmetic/u4/README.md) and catalog

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -30,6 +30,7 @@ each input with the same output-restoration boundary.
 | Checked table batch, 32 nibbles | <!-- metric:u4_bits_checked_batch32 -->924<!-- /metric:u4_bits_checked_batch32 --> bytes | <!-- metric:u4_bits_checked_batch32_stack -->189<!-- /metric:u4_bits_checked_batch32_stack --> items | <!-- metric:u4_bits_checked_batch32_opcodes -->735<!-- /metric:u4_bits_checked_batch32_opcodes --> |
 | Unchecked table batch, 32 nibbles | <!-- metric:u4_bits_unchecked_batch32 -->764<!-- /metric:u4_bits_unchecked_batch32 --> bytes | 189 items | not recorded |
 | Existing branch splitter, 32 four-bit limbs | <!-- metric:u4_bits_branch_batch32 -->1374<!-- /metric:u4_bits_branch_batch32 --> bytes | <!-- metric:u4_bits_branch_batch32_stack -->130<!-- /metric:u4_bits_branch_batch32_stack --> items | not recorded |
+| `verify_canonical_nibble()` | <!-- metric:u4_canonical_nibble -->10<!-- /metric:u4_canonical_nibble --> bytes | <!-- metric:u4_canonical_nibble_witness -->3<!-- /metric:u4_canonical_nibble_witness --> bytes, 1 data item | <!-- metric:u4_canonical_nibble_stack -->4<!-- /metric:u4_canonical_nibble_stack --> items |
 
 The staggered table has 61 setup items and costs 31 bytes to remove. A checked
 query costs 22 bytes and restoring its four bits costs another four, so the

--- a/src/arithmetic/u4/stack.rs
+++ b/src/arithmetic/u4/stack.rs
@@ -91,6 +91,14 @@ pub fn u4_hex_to_nibbles(hex_str: &str) -> Script {
     }
 }
 
+/// Preserve the top value after proving it is a canonical ScriptNum nibble.
+pub fn verify_canonical_nibble() -> Script {
+    script! {
+        OP_DUP 0 16 OP_WITHIN OP_VERIFY
+        OP_DUP OP_DUP 0 OP_ADD OP_EQUALVERIFY
+    }
+}
+
 pub fn u4_repeat_number(n: u32, count: u32) -> Script {
     match count {
         0 => script! {},
@@ -200,5 +208,41 @@ mod tests {
             OP_TRUE
         };
         crate::support::execution::run(script);
+    }
+    #[test]
+    fn canonical_nibble_boundary_rejects_aliases_and_out_of_range_values() {
+        for value in 0..=15 {
+            let mut bytes = [0u8; 8];
+            let length = bitcoin::script::write_scriptint(&mut bytes, i64::from(value));
+            let encoded = bytes[..length].to_vec();
+            let result = crate::support::execution::execute_script_with_inputs(
+                script! {
+                    5 OP_TOALTSTACK
+                    { verify_canonical_nibble() }
+                    { value } OP_EQUALVERIFY
+                    OP_FROMALTSTACK 5 OP_EQUALVERIFY
+                    99 OP_EQUAL
+                },
+                vec![vec![99], encoded],
+            );
+            assert!(
+                result.success,
+                "rejected canonical nibble {value}: {result}"
+            );
+        }
+
+        for encoded in [
+            vec![1, 0],          // redundant positive sign byte
+            vec![0x80],          // negative zero
+            vec![16],            // canonical but outside the nibble range
+            vec![0xff],          // negative value
+            vec![0, 0, 0, 0, 0], // oversized zero
+        ] {
+            let result = crate::support::execution::execute_script_with_inputs(
+                script! { { verify_canonical_nibble() } },
+                vec![encoded],
+            );
+            assert!(!result.success, "accepted malformed nibble: {result}");
+        }
     }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,37 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+#[test]
+fn u4_canonical_nibble_metrics_are_current() {
+    let fragment = u4::stack::verify_canonical_nibble();
+    let witness = vec![scriptnum(15)];
+    let stack = max_stack_items_strict(
+        script! {
+            { fragment.clone() }
+            OP_DROP
+            OP_1
+        },
+        witness.clone(),
+    );
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_canonical_nibble",
+            value: script_len(fragment),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_canonical_nibble_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_canonical_nibble_stack",
+            value: stack,
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Research question
Can a nibble witness be checked for both numeric range and byte-unique ScriptNum encoding with a small reusable fragment?

## Summary
- add `verify_canonical_nibble()`, preserving the accepted value
- reject redundant sign bytes, negative zero, negative values, out-of-range values, and oversized encodings
- record the 10-byte fragment, 3-byte representative witness, and 4-item strict peak

## Validation
- `cargo test --locked arithmetic::u4::stack::tests::canonical_nibble_boundary_rejects_aliases_and_out_of_range_values`
- `cargo test --locked --test primitive_metrics u4_canonical_nibble_metrics_are_current`
- `python3 tools/kb.py validate`
- `cargo fmt --all -- --check`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the new trust boundary. Execution remains locally reproduced and unclassified, with no cryptographic or deployment claim.