### PR TITLE
feat(u32): add canonical byte boundary

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -263,6 +263,28 @@
           "metric_keys": [
             "u8_logic_table_push"
           ]
+        },
+        {
+          "id": "canonical-byte-boundary",
+          "label": "Canonical checked ScriptNum byte",
+          "parameters": {
+            "range": "0..=255",
+            "encoding": "minimal at-most-four-byte ScriptNum"
+          },
+          "includes": "fragment-only: numeric byte range and raw ScriptNum canonicality checks; preserves the value and excludes input push and output check",
+          "script_bytes": 12,
+          "witness_bytes": 4,
+          "witness_bytes_max": 4,
+          "max_stack_items": 4,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 12,
+          "metric_keys": [
+            "u32_canonical_byte",
+            "u32_canonical_byte_witness",
+            "u32_canonical_byte_stack"
+          ]
         }
       ],
       "limitations": [

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -8,6 +8,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small constant product | ScriptNum × 13 | 10 | Four-byte ScriptNum domain |
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
+| Canonical checked byte boundary | `verify_canonical_byte()` | 12 | 4-item peak; 4-byte witness; rejects noncanonical ScriptNums |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -9,7 +9,8 @@ stack manipulation.
 - **Evidence:** locally reproduced, including exhaustive byte-level logic tests.
 - **Tradeoff:** operation fragments are moderate, while a reusable Boolean table
   occupies 256 stack items.
-- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39.
+- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39;
+  `verify_canonical_byte()` provides a byte-unique witness boundary.
 - **Consumers:** SHA-1, SHA-256, RIPEMD-160, and SHAKE256.
 
 See the [implementation README](../../src/arithmetic/u32/README.md),

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -39,6 +39,7 @@ as less-than-or-equal.
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
+| `verify_canonical_byte()` | <!-- metric:u32_canonical_byte -->12<!-- /metric:u32_canonical_byte --> bytes | <!-- metric:u32_canonical_byte_witness -->4<!-- /metric:u32_canonical_byte_witness --> bytes, 1 data item | <!-- metric:u32_canonical_byte_stack -->4<!-- /metric:u32_canonical_byte_stack --> items |
 
 Operand witness serialization is deliberately excluded: callers may construct
 words inside the locking script or supply four witness items per word. No

--- a/src/arithmetic/u32/stack.rs
+++ b/src/arithmetic/u32/stack.rs
@@ -17,6 +17,14 @@ pub fn u32_push(value: u32) -> Script {
     }
 }
 
+/// Preserve the top value after proving it is a canonical ScriptNum byte.
+pub fn verify_canonical_byte() -> Script {
+    script! {
+        OP_DUP 0 256 OP_WITHIN OP_VERIFY
+        OP_DUP OP_DUP 0 OP_ADD OP_EQUALVERIFY
+    }
+}
+
 pub fn u32_equalverify() -> Script {
     script! {
         4
@@ -176,6 +184,40 @@ mod tests {
                 OP_EQUAL
             };
             run(script);
+        }
+    }
+
+    #[test]
+    fn canonical_byte_boundary_rejects_aliases_and_out_of_range_values() {
+        for value in 0..=255 {
+            let mut bytes = [0u8; 8];
+            let length = bitcoin::script::write_scriptint(&mut bytes, i64::from(value));
+            let encoded = bytes[..length].to_vec();
+            let result = crate::support::execution::execute_script_with_inputs(
+                script! {
+                    5 OP_TOALTSTACK
+                    { verify_canonical_byte() }
+                    { value } OP_EQUALVERIFY
+                    OP_FROMALTSTACK 5 OP_EQUALVERIFY
+                    99 OP_EQUAL
+                },
+                vec![vec![99], encoded],
+            );
+            assert!(result.success, "rejected canonical byte {value}: {result}");
+        }
+
+        for encoded in [
+            vec![1, 0],          // redundant positive sign byte
+            vec![0x80],          // negative zero
+            vec![0, 1],          // canonical 256, outside the byte range
+            vec![0xff],          // negative value
+            vec![0, 0, 0, 0, 0], // oversized zero
+        ] {
+            let result = crate::support::execution::execute_script_with_inputs(
+                script! { { verify_canonical_byte() } },
+                vec![encoded],
+            );
+            assert!(!result.success, "accepted malformed byte: {result}");
         }
     }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,37 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+#[test]
+fn u32_canonical_byte_metrics_are_current() {
+    let fragment = u32::stack::verify_canonical_byte();
+    let witness = vec![scriptnum(255)];
+    let stack = max_stack_items_strict(
+        script! {
+            { fragment.clone() }
+            OP_DROP
+            OP_1
+        },
+        witness.clone(),
+    );
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_canonical_byte",
+            value: script_len(fragment),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_canonical_byte_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_canonical_byte_stack",
+            value: stack,
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Research question
Can a hostile byte witness be constrained to both numeric `0..=255` and minimal, byte-unique ScriptNum encoding with a small reusable fragment?

## Summary
- add `verify_canonical_byte()`, preserving the accepted value
- reject redundant sign bytes, negative zero, negative values, canonical `256`, and oversized encodings
- record the 12-byte fragment, 4-byte representative witness, and 4-item strict peak

## Validation
- `cargo test --locked arithmetic::u32::stack::tests::canonical_byte_boundary_rejects_aliases_and_out_of_range_values`
- `cargo test --locked --test primitive_metrics u32_canonical_byte_metrics_are_current`
- `python3 tools/kb.py validate`
- `cargo fmt --all -- --check`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the new trust boundary. Execution remains locally reproduced and unclassified, with no cryptographic or deployment claim.