### PR TITLE
refactor(sha256): reuse shared nibble encoder

### DIFF
--- a/src/hashes/sha256/sha2_u4_stack.rs
+++ b/src/hashes/sha256/sha2_u4_stack.rs
@@ -1,5 +1,6 @@
 use crate::arithmetic::u4::{
     add::{u4_add_carry_nested, u4_add_nested},
+    stack::u4_number_to_nibble,
     stack_add::*,
     stack_logic::*,
     stack_shift::*,
@@ -45,15 +46,6 @@ fn scheduling_64_padding() -> [u32; 64] {
             .wrapping_add(s1);
     }
     result
-}
-
-pub fn u4_number_to_nibble(n: u32) -> Script {
-    //constant number used during "compile" time
-    script! {
-       for i in (0..8).rev() {
-            { (n >> (i * 4)) & 0xF }
-        }
-    }
 }
 
 pub fn double_padding(num_bytes: u32) -> (Vec<Script>, u32) {


### PR DESCRIPTION
## Summary

- remove the duplicate `u4_number_to_nibble()` implementation from the tracked SHA-256 u4 stack generator
- reuse the established `arithmetic::u4::stack::u4_number_to_nibble()` helper
- preserve the generated script and existing public behavior while reducing duplicate maintenance

## Research framing

Question: does the tracked SHA-256 u4 generator need its own fixed-width nibble encoder?

Result: no. The arithmetic u4 module already provides the same eight-nibble compile-time encoder, so the hash generator can share it without changing its stack contract or generated semantics. This is a locally checked maintenance refactor with no new deployment or security claim.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked hashes::sha256::sha2_u4_stack::tests::test_shatemp`
- `cargo test --locked arithmetic::u4::stack::tests`
- `git diff --check`

The full repository test suite was intentionally not run; field-arithmetic tests remain skipped by default.
