### PR TITLE
feat(u32): document byte zip routers

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -263,6 +263,54 @@
           "metric_keys": [
             "u8_logic_table_push"
           ]
+        },
+        {
+          "id": "u32-zip",
+          "label": "u32_zip(0,1)",
+          "parameters": {
+            "first_depth": 0,
+            "second_depth": 1,
+            "input_items": 8,
+            "output_items": 8
+          },
+          "includes": "fragment-only: interleaves two four-byte words by byte position and consumes both inputs; excludes input pushes and output checks",
+          "script_bytes": 16,
+          "witness_bytes": 17,
+          "witness_bytes_max": 17,
+          "max_stack_items": 9,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 16,
+          "metric_keys": [
+            "u32_zip",
+            "u32_zip_witness",
+            "u32_zip_stack"
+          ]
+        },
+        {
+          "id": "u32-copy-zip",
+          "label": "u32_copy_zip(0,1)",
+          "parameters": {
+            "first_depth": 0,
+            "second_depth": 1,
+            "input_items": 8,
+            "output_items": 12
+          },
+          "includes": "fragment-only: interleaves two four-byte words while retaining a copy of the selected top word; excludes input pushes and output checks",
+          "script_bytes": 16,
+          "witness_bytes": 17,
+          "witness_bytes_max": 17,
+          "max_stack_items": 13,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 16,
+          "metric_keys": [
+            "u32_copy_zip",
+            "u32_copy_zip_witness",
+            "u32_copy_zip_stack"
+          ]
         }
       ],
       "limitations": [

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -9,7 +9,9 @@ stack manipulation.
 - **Evidence:** locally reproduced, including exhaustive byte-level logic tests.
 - **Tradeoff:** operation fragments are moderate, while a reusable Boolean table
   occupies 256 stack items.
-- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39.
+- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39;
+  `u32_zip(0, 1)` is 16 bytes at a 9-item peak and
+  `u32_copy_zip(0, 1)` is 16 bytes at a 13-item peak.
 - **Consumers:** SHA-1, SHA-256, RIPEMD-160, and SHAKE256.
 
 See the [implementation README](../../src/arithmetic/u32/README.md),

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -37,6 +37,8 @@ as less-than-or-equal.
 | `u32_lessthanorequal()` | <!-- metric:u32_lessthanorequal -->61<!-- /metric:u32_lessthanorequal --> bytes | 0 bytes | <!-- metric:u32_lessthanorequal_stack -->13<!-- /metric:u32_lessthanorequal_stack --> items |
 | `u32_or(0, 1, 3)` (table excluded) | <!-- metric:u32_or -->326<!-- /metric:u32_or --> bytes | 0 bytes | <!-- metric:u32_or_stack -->272<!-- /metric:u32_or_stack --> items, including table |
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
+| `u32_zip(0, 1)` | <!-- metric:u32_zip -->16<!-- /metric:u32_zip --> bytes | <!-- metric:u32_zip_witness -->17<!-- /metric:u32_zip_witness --> bytes, 8 data items | <!-- metric:u32_zip_stack -->9<!-- /metric:u32_zip_stack --> items |
+| `u32_copy_zip(0, 1)` | <!-- metric:u32_copy_zip -->16<!-- /metric:u32_copy_zip --> bytes | <!-- metric:u32_copy_zip_witness -->17<!-- /metric:u32_copy_zip_witness --> bytes, 8 data items | <!-- metric:u32_copy_zip_stack -->13<!-- /metric:u32_copy_zip_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
 

--- a/src/arithmetic/u32/zip.rs
+++ b/src/arithmetic/u32/zip.rs
@@ -60,3 +60,38 @@ pub fn _u32_zip_copy(mut a: u32, mut b: u32) -> Script {
         {a+3} OP_ROLL {b} OP_PICK
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::support::execution::execute_script;
+
+    #[test]
+    fn zip_and_copy_zip_preserve_documented_byte_order() {
+        let zipped = execute_script(script! {
+            { super::super::stack::u32_push(0x1122_3344) }
+            { super::super::stack::u32_push(0xaabb_ccdd) }
+            { u32_zip(0, 1) }
+            0x44 OP_EQUALVERIFY
+            0xdd OP_EQUALVERIFY
+            0x33 OP_EQUALVERIFY
+            0xcc OP_EQUALVERIFY
+            0x22 OP_EQUALVERIFY
+            0xbb OP_EQUALVERIFY
+            0x11 OP_EQUALVERIFY
+            0xaa OP_EQUALVERIFY
+            OP_TRUE
+        });
+        assert!(zipped.success, "zip order failed: {zipped}");
+
+        let copy = execute_script(script! {
+            { super::super::stack::u32_push(0x1122_3344) }
+            { super::super::stack::u32_push(0xaabb_ccdd) }
+            { u32_copy_zip(0, 1) }
+            OP_DEPTH 12 OP_EQUALVERIFY
+            for _ in 0..12 { OP_DROP }
+            OP_TRUE
+        });
+        assert!(copy.success, "copy_zip output shape failed: {copy}");
+    }
+}

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,61 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+#[test]
+fn u32_zip_metrics_are_current() {
+    let witness = vec![vec![1u8]; 8];
+    let zip = u32::zip::u32_zip(0, 1);
+    let zip_stack = max_stack_items_strict(
+        script! {
+            { zip.clone() }
+            for _ in 0..8 { OP_DROP }
+            OP_TRUE
+        },
+        witness.clone(),
+    );
+    let copy_zip = u32::zip::u32_copy_zip(0, 1);
+    let copy_zip_stack = max_stack_items_strict(
+        script! {
+            { copy_zip.clone() }
+            for _ in 0..12 { OP_DROP }
+            OP_TRUE
+        },
+        witness.clone(),
+    );
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_zip",
+            value: script_len(zip),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_zip_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_zip_stack",
+            value: zip_stack,
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_copy_zip",
+            value: script_len(copy_zip),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_copy_zip_witness",
+            value: witness_size(&witness),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_copy_zip_stack",
+            value: copy_zip_stack,
+        },
+    ]);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary

- add direct correctness coverage for `u32_zip(0, 1)` byte order and `u32_copy_zip(0, 1)` output shape
- document and catalog both existing routing fragments
- record script, serialized witness, and strict combined-stack metrics

## Research framing

Question: what are the executable contracts and measured costs of the u32 byte zip routers already used by add, subtract, AND, OR, and XOR?

Result: `u32_zip(0,1)` is a 16-byte consuming interleaver with an 8-item witness and 9-item strict peak. `u32_copy_zip(0,1)` is a 16-byte interleaver retaining the selected word, with the same witness and a 13-item strict peak.

The evidence is locally reproduced and unclassified for deployment. Inputs are raw byte-valued stack items; callers remain responsible for range and canonical ScriptNum checks.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked arithmetic::u32::zip::tests::zip_and_copy_zip_preserve_documented_byte_order`
- `cargo test --locked --test primitive_metrics u32_zip_metrics_are_current`
- `python3 tools/kb.py validate`
- `git diff --check`

The full repository test suite was intentionally not run; field-arithmetic tests remain skipped by default.
