### PR TITLE
feat(u32): document byte reorder boundary

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -263,6 +263,82 @@
           "metric_keys": [
             "u8_logic_table_push"
           ]
+        },
+        {
+          "id": "byte-reorder-0",
+          "label": "byte_reorder(0)",
+          "parameters": { "offset": 0, "input_items": 4, "output_items": 4 },
+          "includes": "fragment-only: byte permutation; excludes input pushes and output checks",
+          "script_bytes": 3,
+          "witness_bytes": 9,
+          "witness_bytes_max": 9,
+          "max_stack_items": 4,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 3,
+          "metric_keys": [
+            "u32_byte_reorder_0",
+            "u32_byte_reorder_witness_0",
+            "u32_byte_reorder_stack_0"
+          ]
+        },
+        {
+          "id": "byte-reorder-1",
+          "label": "byte_reorder(1)",
+          "parameters": { "offset": 1, "input_items": 4, "output_items": 4 },
+          "includes": "fragment-only: byte permutation; excludes input pushes and output checks",
+          "script_bytes": 2,
+          "witness_bytes": 9,
+          "witness_bytes_max": 9,
+          "max_stack_items": 4,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 2,
+          "metric_keys": [
+            "u32_byte_reorder_1",
+            "u32_byte_reorder_witness_1",
+            "u32_byte_reorder_stack_1"
+          ]
+        },
+        {
+          "id": "byte-reorder-2",
+          "label": "byte_reorder(2)",
+          "parameters": { "offset": 2, "input_items": 4, "output_items": 4 },
+          "includes": "fragment-only: byte permutation; excludes input pushes and output checks",
+          "script_bytes": 4,
+          "witness_bytes": 9,
+          "witness_bytes_max": 9,
+          "max_stack_items": 4,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 4,
+          "metric_keys": [
+            "u32_byte_reorder_2",
+            "u32_byte_reorder_witness_2",
+            "u32_byte_reorder_stack_2"
+          ]
+        },
+        {
+          "id": "byte-reorder-3",
+          "label": "byte_reorder(3)",
+          "parameters": { "offset": 3, "input_items": 4, "output_items": 4 },
+          "includes": "fragment-only: byte permutation; excludes input pushes and output checks",
+          "script_bytes": 3,
+          "witness_bytes": 9,
+          "witness_bytes_max": 9,
+          "max_stack_items": 4,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 3,
+          "metric_keys": [
+            "u32_byte_reorder_3",
+            "u32_byte_reorder_witness_3",
+            "u32_byte_reorder_stack_3"
+          ]
         }
       ],
       "limitations": [

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -9,7 +9,8 @@ stack manipulation.
 - **Evidence:** locally reproduced, including exhaustive byte-level logic tests.
 - **Tradeoff:** operation fragments are moderate, while a reusable Boolean table
   occupies 256 stack items.
-- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39.
+- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39;
+  `byte_reorder(offset)` costs 2–4 bytes across its four offsets.
 - **Consumers:** SHA-1, SHA-256, RIPEMD-160, and SHAKE256.
 
 See the [implementation README](../../src/arithmetic/u32/README.md),

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -37,6 +37,10 @@ as less-than-or-equal.
 | `u32_lessthanorequal()` | <!-- metric:u32_lessthanorequal -->61<!-- /metric:u32_lessthanorequal --> bytes | 0 bytes | <!-- metric:u32_lessthanorequal_stack -->13<!-- /metric:u32_lessthanorequal_stack --> items |
 | `u32_or(0, 1, 3)` (table excluded) | <!-- metric:u32_or -->326<!-- /metric:u32_or --> bytes | 0 bytes | <!-- metric:u32_or_stack -->272<!-- /metric:u32_or_stack --> items, including table |
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
+| `byte_reorder(0)` | <!-- metric:u32_byte_reorder_0 -->3<!-- /metric:u32_byte_reorder_0 --> bytes | <!-- metric:u32_byte_reorder_witness_0 -->9<!-- /metric:u32_byte_reorder_witness_0 --> bytes, 4 data items | <!-- metric:u32_byte_reorder_stack_0 -->4<!-- /metric:u32_byte_reorder_stack_0 --> items |
+| `byte_reorder(1)` | <!-- metric:u32_byte_reorder_1 -->2<!-- /metric:u32_byte_reorder_1 --> bytes | <!-- metric:u32_byte_reorder_witness_1 -->9<!-- /metric:u32_byte_reorder_witness_1 --> bytes, 4 data items | <!-- metric:u32_byte_reorder_stack_1 -->4<!-- /metric:u32_byte_reorder_stack_1 --> items |
+| `byte_reorder(2)` | <!-- metric:u32_byte_reorder_2 -->4<!-- /metric:u32_byte_reorder_2 --> bytes | <!-- metric:u32_byte_reorder_witness_2 -->9<!-- /metric:u32_byte_reorder_witness_2 --> bytes, 4 data items | <!-- metric:u32_byte_reorder_stack_2 -->4<!-- /metric:u32_byte_reorder_stack_2 --> items |
+| `byte_reorder(3)` | <!-- metric:u32_byte_reorder_3 -->3<!-- /metric:u32_byte_reorder_3 --> bytes | <!-- metric:u32_byte_reorder_witness_3 -->9<!-- /metric:u32_byte_reorder_witness_3 --> bytes, 4 data items | <!-- metric:u32_byte_reorder_stack_3 -->4<!-- /metric:u32_byte_reorder_stack_3 --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
 

--- a/src/arithmetic/u32/rotate.rs
+++ b/src/arithmetic/u32/rotate.rs
@@ -267,4 +267,29 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn byte_reorder_covers_all_offsets() {
+        for (offset, expected) in [
+            (0, 0x4433_2211),
+            (1, 0x1144_3322),
+            (2, 0x2211_4433),
+            (3, 0x3322_1144),
+        ] {
+            let result = crate::support::execution::execute_script(script! {
+                { u32_push(0x1122_3344) }
+                { byte_reorder(offset) }
+                { u32_push(expected) }
+                { u32_equal() }
+                OP_VERIFY
+                OP_TRUE
+            });
+            assert!(result.success, "offset {offset} failed: {result}");
+        }
+    }
+
+    #[test]
+    fn byte_reorder_rejects_invalid_offsets() {
+        assert!(std::panic::catch_unwind(|| byte_reorder(4)).is_err());
+    }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -4111,6 +4111,56 @@ fn ed25519_packed_decoder_metrics_are_current() {
     ]);
 }
 
+#[test]
+fn u32_byte_reorder_metrics_are_current() {
+    let witness = vec![vec![1u8]; 4];
+    let mut metrics = Vec::new();
+    for offset in 0..4 {
+        let fragment = u32::rotate::byte_reorder(offset);
+        let stack = max_stack_items_strict(
+            script! {
+                { fragment.clone() }
+                { u32::stack::u32_drop() }
+                OP_TRUE
+            },
+            witness.clone(),
+        );
+        metrics.extend([
+            Metric {
+                readme: "src/arithmetic/u32/README.md",
+                key: match offset {
+                    0 => "u32_byte_reorder_0",
+                    1 => "u32_byte_reorder_1",
+                    2 => "u32_byte_reorder_2",
+                    _ => "u32_byte_reorder_3",
+                },
+                value: script_len(fragment),
+            },
+            Metric {
+                readme: "src/arithmetic/u32/README.md",
+                key: match offset {
+                    0 => "u32_byte_reorder_witness_0",
+                    1 => "u32_byte_reorder_witness_1",
+                    2 => "u32_byte_reorder_witness_2",
+                    _ => "u32_byte_reorder_witness_3",
+                },
+                value: witness_size(&witness),
+            },
+            Metric {
+                readme: "src/arithmetic/u32/README.md",
+                key: match offset {
+                    0 => "u32_byte_reorder_stack_0",
+                    1 => "u32_byte_reorder_stack_1",
+                    2 => "u32_byte_reorder_stack_2",
+                    _ => "u32_byte_reorder_stack_3",
+                },
+                value: stack,
+            },
+        ]);
+    }
+    check_readme_metrics(metrics);
+}
+
 fn check_readme_metrics(metrics: Vec<Metric>) {
     let update = env::var_os("UPDATE_PRIMITIVE_METRICS").is_some();
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Summary

- add direct tests for all four `byte_reorder(offset)` permutations and invalid-offset rejection
- document and catalog each compile-time specialization
- record generated script, serialized witness, and strict stack metrics

## Research framing

Question: what is the exact permutation and cost of the byte reorder used by non-byte-aligned u32 rotations?

Result: offsets 0, 1, 2, and 3 compile to 3, 2, 4, and 3 script bytes respectively. Each consumes four byte items with a 9-byte serialized witness and a 4-item strict peak.

The result is locally reproduced and unclassified for deployment. Inputs are raw byte-valued stack items; callers remain responsible for range and canonical ScriptNum checks.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked byte_reorder_covers_all_offsets`
- `cargo test --locked byte_reorder_rejects_invalid_offsets`
- `cargo test --locked --test primitive_metrics u32_byte_reorder_metrics_are_current`
- `python3 tools/kb.py validate`
- `git diff --check`

The full repository test suite was intentionally not run; field-arithmetic tests remain skipped by default.
