### PR TITLE
feat(u32): document equality boundaries

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -263,6 +263,36 @@
           "metric_keys": [
             "u8_logic_table_push"
           ]
+        },
+        {
+          "id": "equality",
+          "label": "u32_equal()",
+          "parameters": { "input_items": 8, "output_items": 1 },
+          "includes": "fragment-only: four-byte equality reduction; excludes operand pushes and terminal check",
+          "script_bytes": 18,
+          "witness_bytes": 0,
+          "witness_bytes_max": 0,
+          "max_stack_items": 9,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 18,
+          "metric_keys": ["u32_equal", "u32_equal_stack"]
+        },
+        {
+          "id": "equality-verify",
+          "label": "u32_equalverify()",
+          "parameters": { "input_items": 8, "output_items": 0 },
+          "includes": "fragment-only: four-byte equality verification; excludes operand pushes and terminal check",
+          "script_bytes": 9,
+          "witness_bytes": 0,
+          "witness_bytes_max": 0,
+          "max_stack_items": 9,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 9,
+          "metric_keys": ["u32_equalverify", "u32_equalverify_stack"]
         }
       ],
       "limitations": [

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -1,14 +1,17 @@
 # u32 word arithmetic
 
 Represents a 32-bit word as four byte-valued stack items. The module provides
-addition, subtraction, comparison, Boolean operations, shifts, rotations, and
-stack manipulation.
+addition, subtraction, equality and ordering comparison, Boolean operations,
+shifts, rotations, and stack manipulation.
 
 - **Position:** the main local byte-oriented backend for SHA-family and
   RIPEMD-family constructions.
 - **Evidence:** locally reproduced, including exhaustive byte-level logic tests.
 - **Tradeoff:** operation fragments are moderate, while a reusable Boolean table
   occupies 256 stack items.
+- **Equality boundary:** `u32_equal` returns one Boolean result;
+  `u32_equalverify` is the consuming terminal form and fails on any mismatched
+  byte.
 - **Representative results:** add is 78 bytes; subtract is 77; less-than is 39.
 - **Consumers:** SHA-1, SHA-256, RIPEMD-160, and SHAKE256.
 

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -15,6 +15,8 @@ they do not use BN254 or any other field modulus.
   two distinct offsets. The non-`drop` form preserves the minuend.
 - `u32_{less,greater}than[orequal]()` compares the top two words as unsigned
   integers and consumes both.
+- `u32_equal()` consumes the top two words and leaves one Boolean result;
+  `u32_equalverify()` consumes both and fails on mismatch.
 - `u32_or(a, b, stack_size)`, like XOR and AND, takes distinct word offsets.
   `stack_size` is one plus the number of u32 words above the shared byte-logic
   table. With exactly two working words, the usual value is `3`.
@@ -37,6 +39,8 @@ as less-than-or-equal.
 | `u32_lessthanorequal()` | <!-- metric:u32_lessthanorequal -->61<!-- /metric:u32_lessthanorequal --> bytes | 0 bytes | <!-- metric:u32_lessthanorequal_stack -->13<!-- /metric:u32_lessthanorequal_stack --> items |
 | `u32_or(0, 1, 3)` (table excluded) | <!-- metric:u32_or -->326<!-- /metric:u32_or --> bytes | 0 bytes | <!-- metric:u32_or_stack -->272<!-- /metric:u32_or_stack --> items, including table |
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
+| `u32_equal()` | <!-- metric:u32_equal -->18<!-- /metric:u32_equal --> bytes | 0 bytes | <!-- metric:u32_equal_stack -->9<!-- /metric:u32_equal_stack --> items |
+| `u32_equalverify()` | <!-- metric:u32_equalverify -->9<!-- /metric:u32_equalverify --> bytes | 0 bytes | <!-- metric:u32_equalverify_stack -->9<!-- /metric:u32_equalverify_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
 

--- a/src/arithmetic/u32/stack.rs
+++ b/src/arithmetic/u32/stack.rs
@@ -17,6 +17,7 @@ pub fn u32_push(value: u32) -> Script {
     }
 }
 
+/// Consumes two u32 words and fails unless their four byte limbs match.
 pub fn u32_equalverify() -> Script {
     script! {
         4
@@ -31,6 +32,7 @@ pub fn u32_equalverify() -> Script {
     }
 }
 
+/// Consumes two u32 words and leaves one Boolean equality result.
 pub fn u32_equal() -> Script {
     script! {
         4
@@ -160,14 +162,50 @@ mod tests {
     use crate::support::execution::run;
 
     #[test]
-    fn test_u32_notequal() {
+    fn test_u32_equality_boundaries() {
         for (a, b) in [
             (0, 0),
             (0, 1),
             (0xff, 0x100),
+            (0x7fff_ffff, 0x8000_0000),
             (u32::MAX, u32::MAX),
             (u32::MAX, 0),
         ] {
+            run(script! {
+                { u32_push(a) }
+                { u32_push(b) }
+                { u32_equal() }
+                { (a == b) as u32 }
+                OP_EQUAL
+            });
+            let equalverify = crate::support::execution::execute_script(script! {
+                { u32_push(a) }
+                { u32_push(b) }
+                { u32_equalverify() }
+                OP_1
+            });
+            assert_eq!(equalverify.success, a == b);
+        }
+    }
+
+    #[test]
+    fn equality_rejects_a_short_word() {
+        let result = crate::support::execution::execute_script(script! {
+            0
+            0
+            0
+            0
+            0
+            0
+            0
+            { u32_equal() }
+        });
+        assert!(!result.success);
+    }
+
+    #[test]
+    fn test_u32_notequal() {
+        for (a, b) in [(0, 0), (0, 1), (u32::MAX, u32::MAX), (u32::MAX, 0)] {
             let script = script! {
                 { u32_push(a) }
                 { u32_push(b) }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -2230,6 +2230,41 @@ fn metrics() -> Vec<Metric> {
         },
         Metric {
             readme: "src/arithmetic/u32/README.md",
+            key: "u32_equal",
+            value: script_len(u32::stack::u32_equal()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_equal_stack",
+            value: max_stack_items(
+                script! {
+                    { u32::stack::u32_push(0) }
+                    { u32::stack::u32_push(1) }
+                    { u32::stack::u32_equal() }
+                },
+                vec![],
+            ),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_equalverify",
+            value: script_len(u32::stack::u32_equalverify()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_equalverify_stack",
+            value: max_stack_items(
+                script! {
+                    { u32::stack::u32_push(0) }
+                    { u32::stack::u32_push(0) }
+                    { u32::stack::u32_equalverify() }
+                    OP_1
+                },
+                vec![],
+            ),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
             key: "u8_logic_table_push",
             value: script_len(u32::xor::u8_push_xor_table()),
         },


### PR DESCRIPTION
## Summary
- document the existing `u32_equal()` and `u32_equalverify()` stack contracts
- add boundary and short-word rejection tests
- add measured README and catalog records for both equality forms

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked arithmetic::u32::stack::tests`
- `cargo test --locked --test primitive_metrics`
- `python3 tools/kb.py validate`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the changed primitive as requested.
