### PR TITLE
feat(u32): document seven-bit rotation

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -263,6 +263,21 @@
           "metric_keys": [
             "u8_logic_table_push"
           ]
+        },
+        {
+          "id": "fixed-rotation-7",
+          "label": "u32_rrot7()",
+          "parameters": { "rotation": 7, "input_items": 4, "output_items": 4 },
+          "includes": "fragment-only: fixed seven-bit rotation; excludes input pushes and output checks",
+          "script_bytes": 76,
+          "witness_bytes": 0,
+          "witness_bytes_max": 9,
+          "max_stack_items": 8,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 76,
+          "metric_keys": ["u32_rrot7", "u32_rrot7_witness", "u32_rrot7_stack"]
         }
       ],
       "limitations": [

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -9,6 +9,8 @@ stack manipulation.
 - **Evidence:** locally reproduced, including exhaustive byte-level logic tests.
 - **Tradeoff:** operation fragments are moderate, while a reusable Boolean table
   occupies 256 stack items.
+- **Rotation boundary:** `u32_rrot7` rotates the complete four-byte word by
+  seven bits, including the cross-byte carry, and is the fixed SHA-256 form.
 - **Representative results:** add is 78 bytes; subtract is 77; less-than is 39.
 - **Consumers:** SHA-1, SHA-256, RIPEMD-160, and SHAKE256.
 

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -20,6 +20,8 @@ they do not use BN254 or any other field modulus.
   table. With exactly two working words, the usual value is `3`.
 - Stack helpers use whole-word offsets. Rotation helpers additionally take a
   rotation count. There are no implicit parameter defaults.
+- `u32_rrot7()` is the fixed seven-bit right rotation used by SHA-256 and
+  consumes one four-byte word.
 
 ## Script metrics
 
@@ -37,6 +39,7 @@ as less-than-or-equal.
 | `u32_lessthanorequal()` | <!-- metric:u32_lessthanorequal -->61<!-- /metric:u32_lessthanorequal --> bytes | 0 bytes | <!-- metric:u32_lessthanorequal_stack -->13<!-- /metric:u32_lessthanorequal_stack --> items |
 | `u32_or(0, 1, 3)` (table excluded) | <!-- metric:u32_or -->326<!-- /metric:u32_or --> bytes | 0 bytes | <!-- metric:u32_or_stack -->272<!-- /metric:u32_or_stack --> items, including table |
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
+| `u32_rrot7()` | <!-- metric:u32_rrot7 -->76<!-- /metric:u32_rrot7 --> bytes | <!-- metric:u32_rrot7_witness -->9<!-- /metric:u32_rrot7_witness --> bytes, 4 data items | <!-- metric:u32_rrot7_stack -->8<!-- /metric:u32_rrot7_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
 

--- a/src/arithmetic/u32/rotate.rs
+++ b/src/arithmetic/u32/rotate.rs
@@ -38,7 +38,7 @@ pub fn u8_rrot7(i: u32) -> Script {
     }
 }
 
-/// Right rotation of an u32 element by 7 bits
+/// Right rotation of a u32 element by the fixed SHA-256 shift of 7 bits.
 pub fn u32_rrot7() -> Script {
     script! {
         // First Byte
@@ -266,5 +266,33 @@ mod tests {
                 run(script);
             }
         }
+    }
+
+    #[test]
+    fn fixed_rotation7_matches_reference_boundaries() {
+        for value in [0, 1, 0x80, 0x1122_3344, 0x8000_0000, u32::MAX] {
+            let expected = rrot(value, 7);
+            run(script! {
+                { u32_push(value) }
+                { u32_rrot7() }
+                { u32_push(expected) }
+                { u32_equal() }
+                OP_VERIFY
+                OP_1
+            });
+        }
+    }
+
+    #[test]
+    fn fixed_rotation7_rejects_a_short_word() {
+        assert!(std::panic::catch_unwind(|| {
+            crate::support::execution::execute_script(script! {
+                0
+                0
+                0
+                { u32_rrot7() }
+            });
+        })
+        .is_err());
     }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -2230,6 +2230,29 @@ fn metrics() -> Vec<Metric> {
         },
         Metric {
             readme: "src/arithmetic/u32/README.md",
+            key: "u32_rrot7",
+            value: script_len(u32::rotate::u32_rrot7()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_rrot7_witness",
+            value: witness_size(&vec![vec![0u8]; 4]),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_rrot7_stack",
+            value: max_stack_items(
+                script! {
+                    { u32::stack::u32_push(0x0123_4567) }
+                    { u32::rotate::u32_rrot7() }
+                    { u32::stack::u32_drop() }
+                    OP_1
+                },
+                vec![],
+            ),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
             key: "u8_logic_table_push",
             value: script_len(u32::xor::u8_push_xor_table()),
         },


### PR DESCRIPTION
## Summary
- document the existing fixed `u32_rrot7()` SHA-256 rotation
- add deterministic boundary vectors and short-word rejection coverage
- add measured README and catalog records

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked arithmetic::u32::rotate::tests::fixed_rotation7`
- `python3 tools/kb.py validate`
- `cargo test --locked --test primitive_metrics`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the changed primitive as requested.
