### PR TITLE
feat(u4): document altstack transport

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -185,6 +185,36 @@
             "u4_bits_checked_batch32_stack",
             "u4_bits_checked_batch32_opcodes"
           ]
+        },
+        {
+          "id": "altstack-transport-4",
+          "label": "u4_toaltstack(4)",
+          "parameters": { "items": 4 },
+          "includes": "fragment-only: four-item main-to-altstack transport; excludes item pushes and terminal check",
+          "script_bytes": 4,
+          "witness_bytes": 0,
+          "witness_bytes_max": 0,
+          "max_stack_items": 4,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 4,
+          "metric_keys": ["u4_toaltstack4", "u4_toaltstack4_stack"]
+        },
+        {
+          "id": "altstack-transport-4-return",
+          "label": "u4_fromaltstack(4)",
+          "parameters": { "items": 4 },
+          "includes": "fragment-only: four-item altstack-to-main transport; excludes setup, cleanup, and terminal check",
+          "script_bytes": 4,
+          "witness_bytes": 0,
+          "witness_bytes_max": 0,
+          "max_stack_items": 4,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 4,
+          "metric_keys": ["u4_fromaltstack4", "u4_fromaltstack4_stack"]
         }
       ],
       "limitations": [

--- a/knowledge/primitives/u4.md
+++ b/knowledge/primitives/u4.md
@@ -17,6 +17,9 @@ variants. It is a backend for bit-oriented hashes and block ciphers.
 - **Input boundary:** the checked decomposition proves numeric range `0..=15`;
   unchecked lookup requires previously certified nibbles and neither form alone
   proves byte-unique ScriptNum encoding.
+- **Stack transport:** `u4_toaltstack(n)` and `u4_fromaltstack(n)` move a
+  contiguous nibble run without changing its order or disturbing older
+  altstack state.
 - **Consumers:** u4 SHA-256, AES-128, and PRINCEv2.
 
 See the [implementation README](../../src/arithmetic/u4/README.md) and catalog

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -12,6 +12,8 @@ these operations, but this module contains no hash-specific round logic.
   `1..=3` bit counts unless their function documents otherwise.
 - `bits::u4_nibbles_to_be_bits[_toaltstack](nibble_count, check_inputs)` takes
   an explicit batch size in `1..=234` and has no default for input checking.
+- `stack::u4_toaltstack(n)` and `stack::u4_fromaltstack(n)` transport exactly
+  `n` nibble items while preserving their order; `n=0` is a no-op.
 
 ## Script metrics
 
@@ -24,6 +26,8 @@ each input with the same output-restoration boundary.
 | Fragment | Locking script | Maximum combined stack | Executed non-push opcodes |
 | --- | ---: | ---: | ---: |
 | `u4_push_add_tables()` | <!-- metric:u4_add_tables -->92<!-- /metric:u4_add_tables --> bytes | instance-specific | not recorded |
+| `u4_toaltstack(4)` | <!-- metric:u4_toaltstack4 -->4<!-- /metric:u4_toaltstack4 --> bytes | 0 bytes | <!-- metric:u4_toaltstack4_stack -->4<!-- /metric:u4_toaltstack4_stack --> items |
+| `u4_fromaltstack(4)` | <!-- metric:u4_fromaltstack4 -->4<!-- /metric:u4_fromaltstack4 --> bytes | 0 bytes | <!-- metric:u4_fromaltstack4_stack -->4<!-- /metric:u4_fromaltstack4_stack --> items |
 | Staggered bit-table setup | <!-- metric:u4_bits_table_push -->61<!-- /metric:u4_bits_table_push --> bytes | 61 table items | not recorded |
 | Staggered bit-table cleanup | <!-- metric:u4_bits_table_drop -->31<!-- /metric:u4_bits_table_drop --> bytes | consumes 61 items | not recorded |
 | One checked table query, output on altstack | <!-- metric:u4_bits_checked_query -->22<!-- /metric:u4_bits_checked_query --> bytes | composition-dependent | not recorded |

--- a/src/arithmetic/u4/stack.rs
+++ b/src/arithmetic/u4/stack.rs
@@ -1,6 +1,7 @@
 use crate::support::script::*;
 use bitcoin::{opcodes::all::*, Opcode};
 
+/// Moves the top `n` stack items to the altstack, preserving their order.
 pub fn u4_toaltstack(n: u32) -> Script {
     script! {
         for _ in 0..n {
@@ -9,6 +10,7 @@ pub fn u4_toaltstack(n: u32) -> Script {
     }
 }
 
+/// Moves `n` items from the altstack to the main stack, preserving their order.
 pub fn u4_fromaltstack(n: u32) -> Script {
     script! {
         for _ in 0..n {
@@ -175,6 +177,37 @@ mod tests {
             OP_TRUE
         };
         crate::support::execution::run(script);
+    }
+
+    #[test]
+    fn altstack_transport_preserves_order_and_existing_state() {
+        crate::support::execution::run(script! {
+            42 OP_TOALTSTACK
+            1 2 3 4
+            { u4_toaltstack(4) }
+            { u4_fromaltstack(4) }
+            4 OP_EQUALVERIFY
+            3 OP_EQUALVERIFY
+            2 OP_EQUALVERIFY
+            1 OP_EQUALVERIFY
+            OP_FROMALTSTACK 42 OP_EQUAL
+        });
+    }
+
+    #[test]
+    fn altstack_transport_zero_is_a_noop() {
+        crate::support::execution::run(script! {
+            42 OP_TOALTSTACK
+            { u4_toaltstack(0) }
+            { u4_fromaltstack(0) }
+            OP_FROMALTSTACK 42 OP_EQUAL
+        });
+    }
+
+    #[test]
+    fn fromaltstack_rejects_missing_items() {
+        let result = crate::support::execution::execute_script(script! { { u4_fromaltstack(1) } });
+        assert!(!result.success);
     }
 
     #[test]

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -2062,6 +2062,42 @@ fn metrics() -> Vec<Metric> {
         },
         Metric {
             readme: "src/arithmetic/u4/README.md",
+            key: "u4_toaltstack4",
+            value: script_len(u4::stack::u4_toaltstack(4)),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_toaltstack4_stack",
+            value: max_stack_items(
+                script! {
+                    1 2 3 4
+                    { u4::stack::u4_toaltstack(4) }
+                    OP_TRUE
+                },
+                vec![],
+            ),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_fromaltstack4",
+            value: script_len(u4::stack::u4_fromaltstack(4)),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_fromaltstack4_stack",
+            value: max_stack_items(
+                script! {
+                    1 2 3 4
+                    { u4::stack::u4_toaltstack(4) }
+                    { u4::stack::u4_fromaltstack(4) }
+                    { u4::stack::u4_drop(4) }
+                    OP_TRUE
+                },
+                vec![],
+            ),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
             key: "u4_bits_table_push",
             value: script_len(u4::bits::u4_push_to_be_bits_table()),
         },


### PR DESCRIPTION
## Summary
- document the existing `u4_toaltstack(n)` and `u4_fromaltstack(n)` contracts
- add order, pre-existing-altstack, zero-item, and missing-item tests
- add measured four-item transport records to the README and catalog

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked arithmetic::u4::stack::tests`
- `cargo test --locked --test primitive_metrics`
- `python3 tools/kb.py validate`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the changed primitive as requested.
