### PR TITLE
feat(u4): document staged word verification

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -163,6 +163,21 @@
           ]
         },
         {
+          "id": "verify-u32-from-altstack",
+          "label": "u4_u32_verify_from_altstack()",
+          "parameters": { "items": 8 },
+          "includes": "fragment-only: staged eight-nibble equality verification; excludes both word pushes and terminal check",
+          "script_bytes": 32,
+          "witness_bytes": 0,
+          "witness_bytes_max": 0,
+          "max_stack_items": 17,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 32,
+          "metric_keys": ["u4_u32_verify_from_altstack", "u4_u32_verify_from_altstack_stack"]
+        },
+        {
           "id": "nibble-to-bits-batch32-checked",
           "label": "Checked 32-nibble staggered-table decomposition",
           "parameters": {

--- a/knowledge/primitives/u4.md
+++ b/knowledge/primitives/u4.md
@@ -17,6 +17,8 @@ variants. It is a backend for bit-oriented hashes and block ciphers.
 - **Input boundary:** the checked decomposition proves numeric range `0..=15`;
   unchecked lookup requires previously certified nibbles and neither form alone
   proves byte-unique ScriptNum encoding.
+- **Staged verification:** `u4_u32_verify_from_altstack` binds a staged
+  eight-nibble word to the top main-stack word and rejects any mismatch.
 - **Consumers:** u4 SHA-256, AES-128, and PRINCEv2.
 
 See the [implementation README](../../src/arithmetic/u4/README.md) and catalog

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -12,6 +12,8 @@ these operations, but this module contains no hash-specific round logic.
   `1..=3` bit counts unless their function documents otherwise.
 - `bits::u4_nibbles_to_be_bits[_toaltstack](nibble_count, check_inputs)` takes
   an explicit batch size in `1..=234` and has no default for input checking.
+- `stack::u4_u32_verify_from_altstack()` compares a staged eight-nibble word
+  with the top main-stack word and consumes both on success.
 
 ## Script metrics
 
@@ -24,6 +26,7 @@ each input with the same output-restoration boundary.
 | Fragment | Locking script | Maximum combined stack | Executed non-push opcodes |
 | --- | ---: | ---: | ---: |
 | `u4_push_add_tables()` | <!-- metric:u4_add_tables -->92<!-- /metric:u4_add_tables --> bytes | instance-specific | not recorded |
+| `u4_u32_verify_from_altstack()` | <!-- metric:u4_u32_verify_from_altstack -->32<!-- /metric:u4_u32_verify_from_altstack --> bytes | 0 bytes | <!-- metric:u4_u32_verify_from_altstack_stack -->17<!-- /metric:u4_u32_verify_from_altstack_stack --> items |
 | Staggered bit-table setup | <!-- metric:u4_bits_table_push -->61<!-- /metric:u4_bits_table_push --> bytes | 61 table items | not recorded |
 | Staggered bit-table cleanup | <!-- metric:u4_bits_table_drop -->31<!-- /metric:u4_bits_table_drop --> bytes | consumes 61 items | not recorded |
 | One checked table query, output on altstack | <!-- metric:u4_bits_checked_query -->22<!-- /metric:u4_bits_checked_query --> bytes | composition-dependent | not recorded |

--- a/src/arithmetic/u4/stack.rs
+++ b/src/arithmetic/u4/stack.rs
@@ -45,6 +45,8 @@ pub fn verify_n(n: u32) -> Script {
     }
 }
 
+/// Verifies the top eight main-stack nibbles against eight staged altstack
+/// nibbles and consumes both words on success.
 pub fn u4_u32_verify_from_altstack() -> Script {
     script! {
         for _ in 0..8 {
@@ -175,6 +177,36 @@ mod tests {
             OP_TRUE
         };
         crate::support::execution::run(script);
+    }
+
+    #[test]
+    fn altstack_word_verifier_accepts_match_and_rejects_mismatch() {
+        let matching = crate::support::execution::execute_script(script! {
+            { u4_number_to_nibble(0x1234_5678) }
+            { u4_number_to_nibble(0x1234_5678) }
+            { u4_toaltstack(8) }
+            { u4_u32_verify_from_altstack() }
+            OP_TRUE
+        });
+        assert!(matching.success);
+
+        let mismatching = crate::support::execution::execute_script(script! {
+            { u4_number_to_nibble(0x1234_5678) }
+            { u4_number_to_nibble(0x1234_5679) }
+            { u4_toaltstack(8) }
+            { u4_u32_verify_from_altstack() }
+            OP_TRUE
+        });
+        assert!(!mismatching.success);
+    }
+
+    #[test]
+    fn altstack_word_verifier_rejects_missing_staged_word() {
+        let result = crate::support::execution::execute_script(script! {
+            { u4_number_to_nibble(0x1234_5678) }
+            { u4_u32_verify_from_altstack() }
+        });
+        assert!(!result.success);
     }
 
     #[test]

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -2062,6 +2062,25 @@ fn metrics() -> Vec<Metric> {
         },
         Metric {
             readme: "src/arithmetic/u4/README.md",
+            key: "u4_u32_verify_from_altstack",
+            value: script_len(u4::stack::u4_u32_verify_from_altstack()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_u32_verify_from_altstack_stack",
+            value: max_stack_items(
+                script! {
+                    { u4::stack::u4_number_to_nibble(0x1234_5678) }
+                    { u4::stack::u4_number_to_nibble(0x1234_5678) }
+                    { u4::stack::u4_toaltstack(8) }
+                    { u4::stack::u4_u32_verify_from_altstack() }
+                    OP_TRUE
+                },
+                vec![],
+            ),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
             key: "u4_bits_table_push",
             value: script_len(u4::bits::u4_push_to_be_bits_table()),
         },


### PR DESCRIPTION
## Summary
- document the existing `u4_u32_verify_from_altstack()` stack contract
- add deterministic matching, mismatch, and missing-altstack tests
- add measured README and catalog coverage for the staged verifier

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked arithmetic::u4::stack::tests::altstack_word_verifier`
- `cargo test --locked --test primitive_metrics`
- `python3 tools/kb.py validate`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the changed primitive as requested.
