### PR TITLE
feat(u4): document lookup table schedules

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -11,7 +11,7 @@
       "status": "active",
       "evidence": "locally-reproduced",
       "execution": "unclassified",
-      "as_of": "2026-09-01",
+      "as_of": "2026-09-11",
       "knowledge_page": "knowledge/primitives/scriptnum-constant-mul.md",
       "implementation": "src/arithmetic/scriptint/mod.rs",
       "documentation": "src/arithmetic/scriptint/README.md",
@@ -160,6 +160,86 @@
           "per_use_script_bytes": null,
           "metric_keys": [
             "u4_add_tables"
+          ]
+        },
+        {
+          "id": "half-lookup-setup",
+          "label": "Triangular half lookup table setup",
+          "parameters": {
+            "table_items": 16,
+            "addressing": "sorted triangular offsets"
+          },
+          "includes": "fragment-only: 16-item lookup-table setup; excludes pairwise queries, cleanup, and unrelated live state",
+          "script_bytes": 35,
+          "witness_bytes": 0,
+          "witness_bytes_max": 0,
+          "max_stack_items": 16,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 35,
+          "per_use_script_bytes": null,
+          "metric_keys": [
+            "u4_half_lookup_push"
+          ]
+        },
+        {
+          "id": "half-lookup-cleanup",
+          "label": "Triangular half lookup table cleanup",
+          "parameters": {
+            "table_items": 16,
+            "addressing": "matching destructive drop"
+          },
+          "includes": "fragment-only: cleanup of an existing 16-item triangular lookup table; excludes pairwise queries and unrelated live state",
+          "script_bytes": 8,
+          "witness_bytes": 0,
+          "witness_bytes_max": 0,
+          "max_stack_items": 16,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": null,
+          "metric_keys": [
+            "u4_half_lookup_drop"
+          ]
+        },
+        {
+          "id": "full-lookup-setup",
+          "label": "Linear full lookup table setup",
+          "parameters": {
+            "table_items": 17,
+            "addressing": "linear offsets"
+          },
+          "includes": "fragment-only: 17-item lookup-table setup; excludes pairwise queries, cleanup, and unrelated live state",
+          "script_bytes": 41,
+          "witness_bytes": 0,
+          "witness_bytes_max": 0,
+          "max_stack_items": 17,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 41,
+          "per_use_script_bytes": null,
+          "metric_keys": [
+            "u4_full_lookup_push"
+          ]
+        },
+        {
+          "id": "full-lookup-cleanup",
+          "label": "Linear full lookup table cleanup",
+          "parameters": {
+            "table_items": 17,
+            "addressing": "matching destructive drop"
+          },
+          "includes": "fragment-only: cleanup of an existing 17-item linear lookup table; excludes pairwise queries and unrelated live state",
+          "script_bytes": 9,
+          "witness_bytes": 0,
+          "witness_bytes_max": 0,
+          "max_stack_items": 17,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": null,
+          "metric_keys": [
+            "u4_full_lookup_drop"
           ]
         },
         {

--- a/knowledge/comparisons/lookup-strategies.md
+++ b/knowledge/comparisons/lookup-strategies.md
@@ -33,6 +33,19 @@ The upstream direct 64-entry table that motivated this search is not on the
 frontier because it is incorrect as published for multiple nibble values. The
 local staggered layout is a corrected construction, not a verbatim port.
 
+## u4 lookup scheduling
+
+| Schedule | Persistent table items | Addressing | Lifecycle |
+| --- | ---: | --- | --- |
+| Triangular half lookup | 16 | Sort the two nibbles, then use triangular offsets | Explicit setup and cleanup |
+| Linear full lookup | 17 | Direct linear offset | Explicit setup and cleanup |
+
+The half schedule saves one live stack item and is the smaller memory boundary
+for pairwise nibble logic. That is not a complete byte-cost comparison: the
+half query pays for sorting and triangular offset arithmetic, while the full
+query pays for one additional table item. Both schedules require the caller to
+keep the table depth fixed and use the matching cleanup fragment.
+
 ## Native secp256k1 field frontier
 
 | Strategy | Total bytes | Table lifecycle | Computation | Peak items |

--- a/knowledge/primitives/u4.md
+++ b/knowledge/primitives/u4.md
@@ -8,15 +8,21 @@ variants. It is a backend for bit-oriented hashes and block ciphers.
   nibble semantics.
 - **Evidence:** locally reproduced with exhaustive or reference-vector tests for
   core operations.
-- **Representative results:** addition-table setup is 92 script bytes. A
-  checked 32-nibble decomposition is 924 bytes, executes 735 non-push opcodes,
-  and peaks at 189 combined stack items; the equal-boundary branch baseline is
-  1,374 bytes and peaks at 130.
+- **Representative results:** addition-table setup is 92 script bytes. The
+  triangular lookup schedule uses 16 table items, while the linear schedule
+  uses 17; both have explicit setup and cleanup fragments. A checked 32-nibble
+  decomposition is 924 bytes, executes 735 non-push opcodes, and peaks at 189
+  combined stack items; the equal-boundary branch baseline is 1,374 bytes and
+  peaks at 130.
 - **Composition constraint:** table memory and digit-expanded state can dominate
   the 1,000-item stack limit.
 - **Input boundary:** the checked decomposition proves numeric range `0..=15`;
   unchecked lookup requires previously certified nibbles and neither form alone
   proves byte-unique ScriptNum encoding.
+- **Lookup boundary:** half-table queries sort their two nibble indices and use
+  triangular offsets; full-table queries use linear offsets. The table must
+  remain below the caller's live stack state and be removed with the matching
+  cleanup helper.
 - **Consumers:** u4 SHA-256, AES-128, and PRINCEv2.
 
 See the [implementation README](../../src/arithmetic/u4/README.md) and catalog

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -10,6 +10,10 @@ these operations, but this module contains no hash-specific round logic.
   preloaded addition tables are used. There is no universal default.
 - Logic may use full or triangular half tables; shifts and rotations take
   `1..=3` bit counts unless their function documents otherwise.
+- `u4_push_half_lookup()` installs 16 triangular offsets for sorted nibble
+  pairs; `u4_push_full_lookup()` installs 17 linear offsets. Each table must
+  be removed with its matching `u4_drop_*_lookup()` helper before the caller's
+  terminal predicate.
 - `bits::u4_nibbles_to_be_bits[_toaltstack](nibble_count, check_inputs)` takes
   an explicit batch size in `1..=234` and has no default for input checking.
 
@@ -24,12 +28,23 @@ each input with the same output-restoration boundary.
 | Fragment | Locking script | Maximum combined stack | Executed non-push opcodes |
 | --- | ---: | ---: | ---: |
 | `u4_push_add_tables()` | <!-- metric:u4_add_tables -->92<!-- /metric:u4_add_tables --> bytes | instance-specific | not recorded |
+| Half lookup setup | <!-- metric:u4_half_lookup_push -->35<!-- /metric:u4_half_lookup_push --> bytes | 16 table items | not recorded |
+| Half lookup cleanup | <!-- metric:u4_half_lookup_drop -->8<!-- /metric:u4_half_lookup_drop --> bytes | consumes 16 items | not recorded |
+| Half lookup setup/cleanup lifecycle |  | 16 table items | not recorded |
+| Full lookup setup | <!-- metric:u4_full_lookup_push -->41<!-- /metric:u4_full_lookup_push --> bytes | 17 table items | not recorded |
+| Full lookup cleanup | <!-- metric:u4_full_lookup_drop -->9<!-- /metric:u4_full_lookup_drop --> bytes | consumes 17 items | not recorded |
+| Full lookup setup/cleanup lifecycle |  | 17 table items | not recorded |
 | Staggered bit-table setup | <!-- metric:u4_bits_table_push -->61<!-- /metric:u4_bits_table_push --> bytes | 61 table items | not recorded |
 | Staggered bit-table cleanup | <!-- metric:u4_bits_table_drop -->31<!-- /metric:u4_bits_table_drop --> bytes | consumes 61 items | not recorded |
 | One checked table query, output on altstack | <!-- metric:u4_bits_checked_query -->22<!-- /metric:u4_bits_checked_query --> bytes | composition-dependent | not recorded |
 | Checked table batch, 32 nibbles | <!-- metric:u4_bits_checked_batch32 -->924<!-- /metric:u4_bits_checked_batch32 --> bytes | <!-- metric:u4_bits_checked_batch32_stack -->189<!-- /metric:u4_bits_checked_batch32_stack --> items | <!-- metric:u4_bits_checked_batch32_opcodes -->735<!-- /metric:u4_bits_checked_batch32_opcodes --> |
 | Unchecked table batch, 32 nibbles | <!-- metric:u4_bits_unchecked_batch32 -->764<!-- /metric:u4_bits_unchecked_batch32 --> bytes | 189 items | not recorded |
 | Existing branch splitter, 32 four-bit limbs | <!-- metric:u4_bits_branch_batch32 -->1374<!-- /metric:u4_bits_branch_batch32 --> bytes | <!-- metric:u4_bits_branch_batch32_stack -->130<!-- /metric:u4_bits_branch_batch32_stack --> items | not recorded |
+
+The half lookup keeps one fewer persistent item than the full lookup, at the
+cost of sorting the two query nibbles and using triangular offsets. The full
+lookup is simpler to address but keeps one additional item live. Both counts
+are reusable memory boundaries rather than complete query costs.
 
 The staggered table has 61 setup items and costs 31 bytes to remove. A checked
 query costs 22 bytes and restoring its four bits costs another four, so the
@@ -48,6 +63,10 @@ before using a value as an `OP_PICK` index. `check_inputs=false` must be used
 only when a surrounding fragment already established that range: an invalid
 index can otherwise address below the table. The numeric range check does not
 by itself prove a byte-unique ScriptNum encoding.
+
+Lookup-table setup is locking-script-authored, but the query offsets and table
+depths are caller-controlled composition facts. A wrong cleanup width leaves
+table state live, and a wrong lookup depth can read unrelated stack state.
 
 ## Script compatibility and standardness
 

--- a/src/arithmetic/u4/logic.rs
+++ b/src/arithmetic/u4/logic.rs
@@ -246,3 +246,57 @@ pub fn u4_logic_nibs(
 pub fn u4_xor_u32(bases: Vec<u32>, offset: u32, do_xor_with_and: bool) -> Script {
     u4_logic_nibs(8, bases, offset, do_xor_with_and)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::support::execution::execute_script;
+
+    fn assert_table(values: &[u32], push: Script) {
+        let result = execute_script(script! {
+            { push }
+            for value in values {
+                { *value }
+                OP_EQUALVERIFY
+            }
+            OP_TRUE
+        });
+        assert!(result.success, "lookup table mismatch: {result}");
+    }
+
+    #[test]
+    fn lookup_tables_preserve_their_index_schedule() {
+        assert_table(
+            &[
+                16, 31, 45, 58, 70, 81, 91, 100, 108, 115, 121, 126, 130, 133, 135, 136,
+            ],
+            u4_push_half_lookup(),
+        );
+        assert_table(
+            &[
+                0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256,
+            ],
+            u4_push_full_lookup(),
+        );
+    }
+
+    #[test]
+    fn lookup_cleanup_requires_the_matching_table_width() {
+        let result = execute_script(script! {
+            { u4_push_half_lookup() }
+            { u4_drop_full_lookup() }
+            OP_TRUE
+        });
+        assert!(!result.success, "full cleanup accepted a half table");
+
+        let result = execute_script(script! {
+            { u4_push_half_lookup() }
+            { u4_drop_half_lookup() }
+            OP_TRUE
+        });
+        assert!(
+            result.success,
+            "matching half-table cleanup failed: {result}"
+        );
+    }
+}

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -2062,6 +2062,26 @@ fn metrics() -> Vec<Metric> {
         },
         Metric {
             readme: "src/arithmetic/u4/README.md",
+            key: "u4_half_lookup_push",
+            value: script_len(u4::logic::u4_push_half_lookup()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_half_lookup_drop",
+            value: script_len(u4::logic::u4_drop_half_lookup()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_full_lookup_push",
+            value: script_len(u4::logic::u4_push_full_lookup()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_full_lookup_drop",
+            value: script_len(u4::logic::u4_drop_full_lookup()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
             key: "u4_bits_table_push",
             value: script_len(u4::bits::u4_push_to_be_bits_table()),
         },


### PR DESCRIPTION
## Summary

- document the existing triangular 16-item and linear 17-item u4 lookup schedules
- add exact table-shape and mismatched-cleanup tests
- record setup and cleanup byte metrics in the u4 README and knowledge catalog
- clarify lookup-depth and cleanup-width composition obligations

## Validation

- cargo fmt --all -- --check
- cargo test --locked arithmetic::u4::logic::tests
- cargo test --locked --test primitive_metrics
- python3 tools/kb.py validate
- git diff --check

The full repository test suite was intentionally not run; validation is scoped to the new primitive and repository knowledge/metric checks.