### PR TITLE
feat(hors): document index serialization boundary

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -11,7 +11,7 @@
       "status": "active",
       "evidence": "locally-reproduced",
       "execution": "unclassified",
-      "as_of": "2026-09-01",
+      "as_of": "2026-09-11",
       "knowledge_page": "knowledge/primitives/scriptnum-constant-mul.md",
       "implementation": "src/arithmetic/scriptint/mod.rs",
       "documentation": "src/arithmetic/scriptint/README.md",
@@ -2878,6 +2878,33 @@
           "metric_keys": [
             "hors_lock_n32_t8",
             "hors_witness_n32_t8"
+          ]
+        },
+        {
+          "id": "n129-t1-index-boundary",
+          "label": "n=129, t=1, ScriptNum index 127/128 boundary",
+          "parameters": {
+            "n": 129,
+            "t": 1,
+            "preimage_bytes": 32,
+            "index_boundary": [
+              127,
+              128
+            ]
+          },
+          "includes": "fragment-only: locking verifier and serialized one-pair witnesses at the canonical positive ScriptNum sign-padding boundary",
+          "script_bytes": 2792,
+          "witness_bytes": 36,
+          "witness_bytes_max": 37,
+          "max_stack_items": null,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 2792,
+          "metric_keys": [
+            "hors_lock_n129_t1_boundary",
+            "hors_witness_n129_t1_index127",
+            "hors_witness_n129_t1_index128"
           ]
         }
       ],

--- a/knowledge/comparisons/signatures.md
+++ b/knowledge/comparisons/signatures.md
@@ -115,6 +115,10 @@ and nodes. Optional `Preimage16` comparisons follow the hash comparison.
 | FastWots32 strict lookup | 32-byte message | 4,934 | 1,476 / 1,542 | 143 | 733 hashes on the balanced vector; explicit range check |
 | FastWots32 exact + clear | 32-byte message | 5,205 | 1,476 / 1,542 | 137 | Staged digits and Horner checksum; terminal predicate excluded |
 
+The HORS witness serializer uses minimal ScriptNum indices. At `n=129,t=1`,
+crossing from index 127 to 128 adds one serialized witness byte because 128
+requires a positive sign-padding byte.
+
 Locking figures are `fragment-only`; witness figures are full serialized item
 vectors. Recorded Winternitz stack peaks are from complete local compositions, but the metric
 executor disables the consensus stack check and therefore remains

--- a/knowledge/primitives/hors-hash160.md
+++ b/knowledge/primitives/hors-hash160.md
@@ -8,7 +8,9 @@ explicit witness indices.
 - **Evidence:** locally reproduced with boundary, ordering, and malformed
   witnesses.
 - **Representative result:** `n=32,t=8` uses 809 script bytes and a 280-byte
-  witness with 32-byte preimages.
+  witness with 32-byte preimages. At the canonical ScriptNum boundary, an
+  `n=129,t=1` witness grows from 36 bytes at index 127 to 37 bytes at index
+  128 because the latter needs the positive sign-padding byte.
 - **Security:** strictly one-time; concrete forgery probability depends on
   parameters, index derivation, disclosures, and HASH160.
 - **Research need:** specify and test a complete message-to-subset transform

--- a/src/signatures/hors/README.md
+++ b/src/signatures/hors/README.md
@@ -17,6 +17,8 @@ Serialized witness size includes the witness count and item-length prefixes.
 | Configuration | Locking script | Unlocking witness |
 | --- | ---: | ---: |
 | `n=32`, `t=8`, 32-byte preimages | <!-- metric:hors_lock_n32_t8 -->809<!-- /metric:hors_lock_n32_t8 --> bytes | <!-- metric:hors_witness_n32_t8 -->280<!-- /metric:hors_witness_n32_t8 --> bytes |
+| `n=129`, `t=1`, index 127 | <!-- metric:hors_lock_n129_t1_boundary -->2792<!-- /metric:hors_lock_n129_t1_boundary --> bytes | <!-- metric:hors_witness_n129_t1_index127 -->36<!-- /metric:hors_witness_n129_t1_index127 --> bytes |
+| `n=129`, `t=1`, index 128 | 2,792 bytes | <!-- metric:hors_witness_n129_t1_index128 -->37<!-- /metric:hors_witness_n129_t1_index128 --> bytes |
 
 Maximum depth scales approximately with `n + 2t`; the executable tests include
 the documented `n=32,t=8` case and boundary/malformed cases.
@@ -39,4 +41,6 @@ for the exact documented witness.
 
 No hints beyond the required signature data. The witness contains `t`
 `(index, preimage)` pairs in reverse pair order so pair zero is nearest the top;
-see `hors_unlocking_witness` for canonical construction.
+see `hors_unlocking_witness` for canonical construction. Positive index 128 is
+encoded with a sign-padding byte, so its one-pair witness is one byte larger
+than index 127.

--- a/src/signatures/hors/mod.rs
+++ b/src/signatures/hors/mod.rs
@@ -401,6 +401,20 @@ mod tests {
     }
 
     #[test]
+    fn index_serialization_boundary_at_128_is_canonical() {
+        let preimages = (0..129).map(|i| vec![i as u8; 32]).collect::<Vec<_>>();
+        let public_keys = hors_public_keys(&preimages);
+        let locking = hors_locking_script(&public_keys, 1);
+
+        for (index, encoding) in [(127, vec![0x7f]), (128, vec![0x80, 0x00])] {
+            let witness = hors_unlocking_witness(&preimages, &[index]);
+            assert_eq!(witness[0], encoding, "non-canonical index {index}");
+            let result = execute_script_with_inputs(locking.clone(), witness);
+            assert!(result.success, "index {index} failed: {result}");
+        }
+    }
+
+    #[test]
     fn test_hors_multiple_pairs() {
         let n = 10;
         let t = 3;

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -1801,6 +1801,10 @@ fn metrics() -> Vec<Metric> {
     let hors_preimages = (0u8..32).map(|i| vec![i; 32]).collect::<Vec<_>>();
     let hors_public_keys = hors::hors_public_keys(&hors_preimages);
     let hors_witness = hors::hors_unlocking_witness(&hors_preimages, &(0..8).collect::<Vec<_>>());
+    let hors_boundary_preimages = (0u8..=128).map(|i| vec![i; 32]).collect::<Vec<_>>();
+    let hors_boundary_public_keys = hors::hors_public_keys(&hors_boundary_preimages);
+    let hors_boundary_witness_127 = hors::hors_unlocking_witness(&hors_boundary_preimages, &[127]);
+    let hors_boundary_witness_128 = hors::hors_unlocking_witness(&hors_boundary_preimages, &[128]);
     let schnorr_context = bitcoin::secp256k1::Secp256k1::new();
     let schnorr_secret = bitcoin::secp256k1::SecretKey::from_slice(&[3u8; 32]).unwrap();
     let schnorr_keypair =
@@ -3764,6 +3768,21 @@ fn metrics() -> Vec<Metric> {
             readme: "src/signatures/hors/README.md",
             key: "hors_witness_n32_t8",
             value: witness_size(&hors_witness),
+        },
+        Metric {
+            readme: "src/signatures/hors/README.md",
+            key: "hors_lock_n129_t1_boundary",
+            value: script_len(hors::hors_locking_script(&hors_boundary_public_keys, 1)),
+        },
+        Metric {
+            readme: "src/signatures/hors/README.md",
+            key: "hors_witness_n129_t1_index127",
+            value: witness_size(&hors_boundary_witness_127),
+        },
+        Metric {
+            readme: "src/signatures/hors/README.md",
+            key: "hors_witness_n129_t1_index128",
+            value: witness_size(&hors_boundary_witness_128),
         },
         Metric {
             readme: "src/signatures/pointlocks/README.md",


### PR DESCRIPTION
## Summary

- add a deterministic HORS test for the canonical ScriptNum transition at index 127/128
- verify both boundary witnesses execute successfully
- record the 2,792-byte n=129/t=1 verifier and 36/37-byte serialized witnesses
- document the positive sign-padding byte in the HORS comparison and catalog

## Validation

- cargo fmt --all -- --check
- cargo test --locked signatures::hors::tests
- cargo test --locked --test primitive_metrics
- python3 tools/kb.py validate
- git diff --check

The full repository test suite was intentionally not run; validation is scoped to HORS and repository knowledge/metric checks.