### PR TITLE
feat(u4): document word stack routing

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -124,7 +124,7 @@
       "status": "active",
       "evidence": "locally-reproduced",
       "execution": "unclassified",
-      "as_of": "2026-09-01",
+      "as_of": "2026-09-11",
       "knowledge_page": "knowledge/primitives/u4.md",
       "implementation": "src/arithmetic/u4/mod.rs",
       "documentation": "src/arithmetic/u4/README.md",
@@ -140,10 +140,11 @@
         "batch-lookup",
         "digit-arithmetic",
         "lookup-table",
+        "stack-routing",
         "tracked-stack"
       ],
-      "security": "No independent cryptographic claim. Checked bit conversion enforces numeric nibble range before table indexing; unchecked conversion and other u4 operations require callers to supply certified canonical nibbles. Byte-unique ScriptNum encoding remains a protocol obligation where applicable.",
-      "stack_contract": "Values are expanded into four-bit stack digits. The batch bit converter consumes contiguous nibbles, uses a temporary 61-item table, and returns four big-endian bits per input on the main or altstack as selected by the API.",
+      "security": "No independent cryptographic claim. Checked bit conversion enforces numeric nibble range before table indexing; unchecked conversion and other u4 operations require callers to supply certified canonical nibbles. Stack routing trusts generated source depths and does not validate values. Byte-unique ScriptNum encoding remains a protocol obligation where applicable.",
+      "stack_contract": "Values are expanded into four-bit stack digits. The batch bit converter consumes contiguous nibbles, uses a temporary 61-item table, and returns four big-endian bits per input on the main or altstack as selected by the API. Word routing addresses eight-nibble words at generated depths: copy preserves the source, while move repositions it.",
       "configurations": [
         {
           "id": "addition-memory",
@@ -160,6 +161,52 @@
           "per_use_script_bytes": null,
           "metric_keys": [
             "u4_add_tables"
+          ]
+        },
+        {
+          "id": "copy-word-depth8",
+          "label": "Copy an 8-nibble word from depth 8",
+          "parameters": {
+            "word_items": 8,
+            "address": 8,
+            "preserves_source": true
+          },
+          "includes": "fragment-only: eight OP_PICK word-copy routing operations; excludes source pushes, unrelated state, and terminal predicate",
+          "script_bytes": 16,
+          "witness_bytes": 0,
+          "witness_bytes_max": 0,
+          "max_stack_items": 25,
+          "executed_opcodes": 8,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 16,
+          "metric_keys": [
+            "u4_copy_word_depth8",
+            "u4_copy_word_depth8_stack",
+            "u4_copy_word_depth8_opcodes"
+          ]
+        },
+        {
+          "id": "move-word-depth8",
+          "label": "Move an 8-nibble word from depth 8",
+          "parameters": {
+            "word_items": 8,
+            "address": 8,
+            "preserves_source": false
+          },
+          "includes": "fragment-only: eight OP_ROLL word-repositioning operations; excludes source pushes, unrelated state, and terminal predicate",
+          "script_bytes": 16,
+          "witness_bytes": 0,
+          "witness_bytes_max": 0,
+          "max_stack_items": 17,
+          "executed_opcodes": 8,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 16,
+          "metric_keys": [
+            "u4_move_word_depth8",
+            "u4_move_word_depth8_stack",
+            "u4_move_word_depth8_opcodes"
           ]
         },
         {

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,8 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| Preserve an 8-nibble word | `u4_copy_u32_from(8)` | 16 | Adds 8 live items; source depth must remain fixed |
+| Reposition an 8-nibble word | `u4_move_u32_from(8)` | 16 | Destructive routing; source depth must remain fixed |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/u4.md
+++ b/knowledge/primitives/u4.md
@@ -8,7 +8,9 @@ variants. It is a backend for bit-oriented hashes and block ciphers.
   nibble semantics.
 - **Evidence:** locally reproduced with exhaustive or reference-vector tests for
   core operations.
-- **Representative results:** addition-table setup is 92 script bytes. A
+- **Representative results:** addition-table setup is 92 script bytes. Copying
+  an 8-nibble word from depth 8 costs 16 script bytes and peaks at 25 items;
+  moving it costs the same 16 bytes and peaks at 17. A
   checked 32-nibble decomposition is 924 bytes, executes 735 non-push opcodes,
   and peaks at 189 combined stack items; the equal-boundary branch baseline is
   1,374 bytes and peaks at 130.
@@ -17,6 +19,9 @@ variants. It is a backend for bit-oriented hashes and block ciphers.
 - **Input boundary:** the checked decomposition proves numeric range `0..=15`;
   unchecked lookup requires previously certified nibbles and neither form alone
   proves byte-unique ScriptNum encoding.
+- **Routing boundary:** `u4_copy_u32_from(8)` preserves the source word and
+  duplicates eight items; `u4_move_u32_from(8)` repositions it without the
+  duplicate. Both require the generated source depth to remain correct.
 - **Consumers:** u4 SHA-256, AES-128, and PRINCEv2.
 
 See the [implementation README](../../src/arithmetic/u4/README.md) and catalog

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -10,6 +10,10 @@ these operations, but this module contains no hash-specific round logic.
   preloaded addition tables are used. There is no universal default.
 - Logic may use full or triangular half tables; shifts and rotations take
   `1..=3` bit counts unless their function documents otherwise.
+- `u4_copy_u32_from(address)` and `u4_move_u32_from(address)` address an
+  8-nibble word at depths `address..=address+7`. Copy preserves the source and
+  adds eight items; move repositions the word without duplicating it. The
+  address is a generated stack-layout fact, not witness validation.
 - `bits::u4_nibbles_to_be_bits[_toaltstack](nibble_count, check_inputs)` takes
   an explicit batch size in `1..=234` and has no default for input checking.
 
@@ -24,6 +28,8 @@ each input with the same output-restoration boundary.
 | Fragment | Locking script | Maximum combined stack | Executed non-push opcodes |
 | --- | ---: | ---: | ---: |
 | `u4_push_add_tables()` | <!-- metric:u4_add_tables -->92<!-- /metric:u4_add_tables --> bytes | instance-specific | not recorded |
+| Copy 8-nibble word from depth 8 | <!-- metric:u4_copy_word_depth8 -->16<!-- /metric:u4_copy_word_depth8 --> bytes | <!-- metric:u4_copy_word_depth8_stack -->25<!-- /metric:u4_copy_word_depth8_stack --> items | <!-- metric:u4_copy_word_depth8_opcodes -->8<!-- /metric:u4_copy_word_depth8_opcodes --> |
+| Move 8-nibble word from depth 8 | <!-- metric:u4_move_word_depth8 -->16<!-- /metric:u4_move_word_depth8 --> bytes | <!-- metric:u4_move_word_depth8_stack -->17<!-- /metric:u4_move_word_depth8_stack --> items | <!-- metric:u4_move_word_depth8_opcodes -->8<!-- /metric:u4_move_word_depth8_opcodes --> |
 | Staggered bit-table setup | <!-- metric:u4_bits_table_push -->61<!-- /metric:u4_bits_table_push --> bytes | 61 table items | not recorded |
 | Staggered bit-table cleanup | <!-- metric:u4_bits_table_drop -->31<!-- /metric:u4_bits_table_drop --> bytes | consumes 61 items | not recorded |
 | One checked table query, output on altstack | <!-- metric:u4_bits_checked_query -->22<!-- /metric:u4_bits_checked_query --> bytes | composition-dependent | not recorded |

--- a/src/arithmetic/u4/stack.rs
+++ b/src/arithmetic/u4/stack.rs
@@ -201,4 +201,64 @@ mod tests {
         };
         crate::support::execution::run(script);
     }
+
+    #[test]
+    fn word_routing_distinguishes_copy_from_move() {
+        let copy = crate::support::execution::execute_script(script! {
+            for value in 0..8 {
+                { value }
+            }
+            for value in 100..108 {
+                { value }
+            }
+            { u4_copy_u32_from(8) }
+            for value in (0..8).rev() {
+                { value }
+                OP_EQUALVERIFY
+            }
+            for _ in 0..8 {
+                OP_DROP
+            }
+            for value in (0..8).rev() {
+                { value }
+                OP_EQUALVERIFY
+            }
+            OP_TRUE
+        });
+        assert!(copy.success, "copy routing failed: {copy}");
+
+        let move_result = crate::support::execution::execute_script(script! {
+            for value in 0..8 {
+                { value }
+            }
+            for value in 100..108 {
+                { value }
+            }
+            { u4_move_u32_from(8) }
+            for value in (0..8).rev() {
+                { value }
+                OP_EQUALVERIFY
+            }
+            for _ in 0..8 {
+                OP_DROP
+            }
+            OP_TRUE
+        });
+        assert!(move_result.success, "move routing failed: {move_result}");
+        assert!(copy.stats.max_nb_stack_items > move_result.stats.max_nb_stack_items);
+    }
+
+    #[test]
+    fn word_routing_rejects_a_wrong_source_depth() {
+        let result = std::panic::catch_unwind(|| {
+            crate::support::execution::execute_script(script! {
+                for value in 0..16 {
+                    { value }
+                }
+                { u4_copy_u32_from(9) }
+                OP_TRUE
+            })
+        });
+        assert!(result.map(|info| !info.success).unwrap_or(true));
+    }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -1866,6 +1866,47 @@ fn metrics() -> Vec<Metric> {
         }
     };
     let u4_bits_inputs = vec![scriptnum(15); U4_BITS_BATCH as usize];
+    let u4_copy_word_depth8_stack = script! {
+        for value in 0..8 {
+            { value }
+        }
+        for value in 100..108 {
+            { value }
+        }
+        { u4::stack::u4_copy_u32_from(8) }
+        for value in (0..8).rev() {
+            { value }
+            OP_EQUALVERIFY
+        }
+        for _ in 0..8 {
+            OP_DROP
+        }
+        for value in (0..8).rev() {
+            { value }
+            OP_EQUALVERIFY
+        }
+        for _ in 0..8 {
+            OP_DROP
+        }
+        OP_TRUE
+    };
+    let u4_move_word_depth8_stack = script! {
+        for value in 0..8 {
+            { value }
+        }
+        for value in 100..108 {
+            { value }
+        }
+        { u4::stack::u4_move_u32_from(8) }
+        for value in (0..8).rev() {
+            { value }
+            OP_EQUALVERIFY
+        }
+        for _ in 0..8 {
+            OP_DROP
+        }
+        OP_TRUE
+    };
     let aes_zero_key = [0u8; 16];
     let aes_stack_script = script! {
         { aes::aes128_encrypt(aes_zero_key) }
@@ -2059,6 +2100,36 @@ fn metrics() -> Vec<Metric> {
             readme: "src/arithmetic/u4/README.md",
             key: "u4_add_tables",
             value: script_len(u4::add::u4_push_add_tables()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_copy_word_depth8",
+            value: script_len(u4::stack::u4_copy_u32_from(8)),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_copy_word_depth8_stack",
+            value: max_stack_items(u4_copy_word_depth8_stack, vec![]),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_copy_word_depth8_opcodes",
+            value: static_non_push_opcodes(u4::stack::u4_copy_u32_from(8)),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_move_word_depth8",
+            value: script_len(u4::stack::u4_move_u32_from(8)),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_move_word_depth8_stack",
+            value: max_stack_items(u4_move_word_depth8_stack, vec![]),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_move_word_depth8_opcodes",
+            value: static_non_push_opcodes(u4::stack::u4_move_u32_from(8)),
         },
         Metric {
             readme: "src/arithmetic/u4/README.md",


### PR DESCRIPTION
## Summary

- document the existing 8-nibble OP_PICK copy and OP_ROLL move adapters
- add deterministic tests proving source preservation, repositioning, and wrong-depth failure
- measure the 16-byte / 8-opcode routing boundary and 25-item versus 17-item peaks
- update the u4 README, arithmetic comparison, and catalog

## Validation

- cargo fmt --all -- --check
- cargo test --locked arithmetic::u4::stack::tests
- cargo test --locked --test primitive_metrics
- python3 tools/kb.py validate
- git diff --check

The full repository test suite was intentionally not run; validation is scoped to the routing primitive and repository knowledge/metric checks.