### PR TITLE
feat(commitments): add hash path composition

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1564,7 +1564,7 @@
       "status": "experimental",
       "evidence": "locally-reproduced",
       "execution": "research-unlimited",
-      "as_of": "2026-09-01",
+      "as_of": "2026-09-11",
       "knowledge_page": "knowledge/primitives/hash-path-integer.md",
       "implementation": "src/commitments/hash_path.rs",
       "documentation": "src/commitments/README.md",
@@ -1575,7 +1575,8 @@
         "bip-342"
       ],
       "techniques": [
-        "mixed-hash-path"
+        "mixed-hash-path",
+        "nested-hash-state"
       ],
       "security": "Hiding depends on min-entropy in the unrevealed preimage and bits; a nested path starting from a public checkpoint needs high-entropy bits. Final RIPEMD-160 limits generic collision resistance to 80 bits.",
       "stack_contract": "... bitN-1 ... bit0 preimage -> ... value",
@@ -1600,6 +1601,31 @@
             "hash_path_integer_31",
             "hash_path_integer_witness_31",
             "hash_path_integer_stack_31"
+          ]
+        },
+        {
+          "id": "chain-4-3",
+          "label": "Two-round 4+3-bit hash-path chain",
+          "parameters": {
+            "first_bit_width": 4,
+            "second_bit_width": 3,
+            "opening_bytes": 32,
+            "checkpoint_bytes": 20
+          },
+          "includes": "fragment-only: first hash path, explicit intermediate checkpoint equality, second hash path seeded by the retained digest, and final equality; witness includes the serialized seven selector bits and one 32-byte opening",
+          "script_bytes": 110,
+          "witness_bytes": 45,
+          "witness_bytes_max": 45,
+          "max_stack_items": 10,
+          "executed_opcodes": 68,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 110,
+          "metric_keys": [
+            "hash_path_chain_4_3",
+            "hash_path_chain_4_3_witness",
+            "hash_path_chain_4_3_stack",
+            "hash_path_chain_4_3_opcodes"
           ]
         }
       ],

--- a/knowledge/comparisons/commitments.md
+++ b/knowledge/comparisons/commitments.md
@@ -4,6 +4,7 @@
 | --- | --- | ---: | ---: | ---: | --- |
 | Preimage length | `len(preimage)-offset` | 44 | 18–524 | 3 | Range coupled to item size |
 | Mixed hash path | 31 authenticated bits | 520 | 78 | 34 | Mixed-hash assumption; wider opcode cost |
+| Two-round mixed hash chain | 4-bit path → 3-bit path | 110 | 45 | 10 | Checkpoint order and widths are protocol-bound |
 | Four-way mixed hash path | 16 authenticated base-4 digits / 31 bits | 453 | 61 | 19 | Tapscript `MINIMALIF` required; non-standard mixed-hash code |
 | Lamport 2-bit | Select one of four preimages | 96 | 11 | small | Strictly one-time |
 

--- a/knowledge/primitives/hash-path-integer.md
+++ b/knowledge/primitives/hash-path-integer.md
@@ -97,7 +97,9 @@ complete fairness or poker protocol.
   composition.
 - **Evidence:** `locally-reproduced` with canonical-bit, wrong-opening,
   boundary, and nested-composition tests.
-- **Representative result:** 31 bits use a 520-byte fragment, 78-byte serialized
+- **Representative result:** a two-round 4+3-bit chain uses 110 script bytes,
+  45 serialized witness bytes, 68 static non-push opcodes, and 10 stack items.
+  The 31-bit integer path uses a 520-byte fragment, 78-byte serialized
   witness, and 34 stack items.
 - **Security:** the final 160-bit digest caps generic collision resistance at
   80 bits and generic preimage/second-preimage resistance at 160 bits. Binding

--- a/src/commitments/README.md
+++ b/src/commitments/README.md
@@ -131,8 +131,13 @@ the tests with the listed witness.
 | Fragment | Locking script | Unlocking witness | Maximum stack items |
 | --- | ---: | ---: | ---: |
 | `verify_hash_path_to_integer(31, commitment)` | <!-- metric:hash_path_integer_31 -->520<!-- /metric:hash_path_integer_31 --> bytes | <!-- metric:hash_path_integer_witness_31 -->78<!-- /metric:hash_path_integer_witness_31 --> bytes (32-byte nonce, 31 bits) | <!-- metric:hash_path_integer_stack_31 -->34<!-- /metric:hash_path_integer_stack_31 --> |
+| Two-round `verify_hash_path_chain(4, 3)` | <!-- metric:hash_path_chain_4_3 -->110<!-- /metric:hash_path_chain_4_3 --> bytes | <!-- metric:hash_path_chain_4_3_witness -->45<!-- /metric:hash_path_chain_4_3_witness --> bytes (32-byte opening, 7 bits) | <!-- metric:hash_path_chain_4_3_stack -->10<!-- /metric:hash_path_chain_4_3_stack --> |
 | `verify_four_way_hash_path_to_integer(31, commitment)` | <!-- metric:four_way_hash_path_integer_31 -->438<!-- /metric:four_way_hash_path_integer_31 --> bytes | <!-- metric:four_way_hash_path_integer_witness_31 -->61<!-- /metric:four_way_hash_path_integer_witness_31 --> bytes (32-byte nonce, 16 digits) | <!-- metric:four_way_hash_path_integer_stack_31 -->19<!-- /metric:four_way_hash_path_integer_stack_31 --> |
 | `verify_preimage_length(commitment)` | <!-- metric:preimage_length_default -->44<!-- /metric:preimage_length_default --> bytes | <!-- metric:preimage_length_witness_min -->18<!-- /metric:preimage_length_witness_min -->–<!-- metric:preimage_length_witness_max -->524<!-- /metric:preimage_length_witness_max --> bytes (16–520-byte preimage) | <!-- metric:preimage_length_stack -->3<!-- /metric:preimage_length_stack --> |
+
+The two-round composition executes <!-- metric:hash_path_chain_4_3_opcodes -->68<!-- /metric:hash_path_chain_4_3_opcodes --> static non-push opcodes. It reuses
+the first 20-byte digest as the second preimage instead of serializing a
+checkpoint into a separate witness item.
 
 ## Security
 

--- a/src/commitments/hash_path.rs
+++ b/src/commitments/hash_path.rs
@@ -121,6 +121,28 @@ pub fn verify_hash_path(bit_width: usize, commitment: [u8; 20]) -> Script {
     }
 }
 
+/// Verify two ordered hash paths without serializing the intermediate digest.
+///
+/// The first path's digest is duplicated, checked against `first_commitment`,
+/// and then consumed as the second path's preimage. Witness order is
+/// `second_bitN-1 ... second_bit0 first_bitN-1 ... first_bit0 first_preimage`.
+pub fn verify_hash_path_chain(
+    first_bit_width: usize,
+    first_commitment: [u8; 20],
+    second_bit_width: usize,
+    second_commitment: [u8; 20],
+) -> Script {
+    script! {
+        { hash_path_script(first_bit_width) }
+        OP_DUP
+        { first_commitment.to_vec() }
+        OP_EQUALVERIFY
+        { hash_path_script(second_bit_width) }
+        { second_commitment.to_vec() }
+        OP_EQUAL
+    }
+}
+
 /// Verify a generic hash path and save its bits on the altstack.
 ///
 /// Leaves true on the main stack. After verification, bit `N-1` is on top of
@@ -253,19 +275,41 @@ mod tests {
         witness.push(alice_preimage.to_vec());
 
         let result = execute_script_with_inputs(
-            script! {
-                { hash_path_script(alice_bits.len()) }
-                OP_DUP
-                { alice_commitment.to_vec() }
-                OP_EQUALVERIFY
-                { hash_path_script(bob_bits.len()) }
-                { bob_commitment.to_vec() }
-                OP_EQUAL
-            },
+            verify_hash_path_chain(
+                alice_bits.len(),
+                alice_commitment,
+                bob_bits.len(),
+                bob_commitment,
+            ),
             witness,
         );
         assert!(result.success, "{result}");
         assert_eq!(result.final_stack.len(), 1);
+    }
+
+    #[test]
+    fn digest_chain_rejects_a_wrong_intermediate_checkpoint() {
+        let alice_preimage = [0x42; 32];
+        let alice_bits = [true, false, false, true];
+        let bob_bits = [false, true, true];
+        let alice_commitment = hash_path_commitment(&alice_preimage, &alice_bits);
+        let bob_commitment = hash_path_commitment(&alice_commitment, &bob_bits);
+        let mut witness = bob_bits
+            .iter()
+            .rev()
+            .chain(alice_bits.iter().rev())
+            .map(|bit| if *bit { vec![1] } else { vec![] })
+            .collect::<Vec<_>>();
+        witness.push(alice_preimage.to_vec());
+
+        let result = execute_script_with_inputs(
+            verify_hash_path_chain(4, [0x99; 20], 3, bob_commitment),
+            witness,
+        );
+        assert!(
+            !result.success,
+            "accepted a detached intermediate checkpoint"
+        );
     }
 
     #[test]

--- a/src/commitments/mod.rs
+++ b/src/commitments/mod.rs
@@ -12,7 +12,8 @@ pub use four_way_hash_path::{
 };
 pub use hash_path::{
     hash_path_commitment, hash_path_integer_commitment, hash_path_integer_witness,
-    hash_path_script, verify_hash_path, verify_hash_path_to_altstack, verify_hash_path_to_integer,
+    hash_path_script, verify_hash_path, verify_hash_path_chain, verify_hash_path_to_altstack,
+    verify_hash_path_to_integer,
 };
 pub use preimage_length::{
     preimage_length_commitment, verify_preimage_length, verify_preimage_length_with_offset,

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -14,8 +14,10 @@ use bitcoin_lab::{
     ciphers::{aes, prince},
     commitments::{
         four_way_hash_path_integer_commitment, four_way_hash_path_integer_witness,
-        hash_path_integer_commitment, hash_path_integer_witness, preimage_length_commitment,
-        verify_four_way_hash_path_to_integer, verify_hash_path_to_integer, verify_preimage_length,
+        hash_path_commitment as compute_hash_path_commitment, hash_path_integer_commitment,
+        hash_path_integer_witness, preimage_length_commitment,
+        verify_four_way_hash_path_to_integer, verify_hash_path_chain, verify_hash_path_to_integer,
+        verify_preimage_length,
     },
     curves::bn254::groups::{g1::G1Affine, g2::G2Affine},
     fields::{
@@ -1849,6 +1851,26 @@ fn metrics() -> Vec<Metric> {
         four_way_hash_path_integer_commitment(&hash_path_preimage, hash_path_value, 31);
     let four_way_hash_path_witness =
         four_way_hash_path_integer_witness(&hash_path_preimage, hash_path_value, 31);
+    let hash_path_chain_alice_preimage = [0x42; 32];
+    let hash_path_chain_alice_bits = [true, false, false, true];
+    let hash_path_chain_bob_bits = [false, true, true];
+    let hash_path_chain_alice_commitment =
+        compute_hash_path_commitment(&hash_path_chain_alice_preimage, &hash_path_chain_alice_bits);
+    let hash_path_chain_bob_commitment =
+        compute_hash_path_commitment(&hash_path_chain_alice_commitment, &hash_path_chain_bob_bits);
+    let hash_path_chain_witness = hash_path_chain_bob_bits
+        .iter()
+        .rev()
+        .chain(hash_path_chain_alice_bits.iter().rev())
+        .map(|bit| if *bit { vec![1] } else { vec![] })
+        .chain(std::iter::once(hash_path_chain_alice_preimage.to_vec()))
+        .collect::<Vec<_>>();
+    let hash_path_chain_script = verify_hash_path_chain(
+        hash_path_chain_alice_bits.len(),
+        hash_path_chain_alice_commitment,
+        hash_path_chain_bob_bits.len(),
+        hash_path_chain_bob_commitment,
+    );
 
     let length_preimage = vec![0x24; 32];
     let length_commitment = preimage_length_commitment(&length_preimage);
@@ -3700,6 +3722,26 @@ fn metrics() -> Vec<Metric> {
                 verify_hash_path_to_integer(31, hash_path_commitment),
                 hash_path_witness,
             ),
+        },
+        Metric {
+            readme: "src/commitments/README.md",
+            key: "hash_path_chain_4_3",
+            value: script_len(hash_path_chain_script.clone()),
+        },
+        Metric {
+            readme: "src/commitments/README.md",
+            key: "hash_path_chain_4_3_witness",
+            value: witness_size(&hash_path_chain_witness),
+        },
+        Metric {
+            readme: "src/commitments/README.md",
+            key: "hash_path_chain_4_3_stack",
+            value: max_stack_items(hash_path_chain_script.clone(), hash_path_chain_witness),
+        },
+        Metric {
+            readme: "src/commitments/README.md",
+            key: "hash_path_chain_4_3_opcodes",
+            value: static_non_push_opcodes(hash_path_chain_script),
         },
         Metric {
             readme: "src/commitments/README.md",


### PR DESCRIPTION
## Summary
- add a reusable two-round hash-path verifier that feeds the first digest directly into the second path
- bind the intermediate digest to the first commitment before continuing
- document and measure the 4-bit then 3-bit composition boundary

## Evidence
- script: 110 bytes
- witness: 45 bytes
- static non-push opcodes: 68
- measured stack peak: 10 items

## Validation
- `cargo test --locked commitments::hash_path::tests`
- `cargo test --locked --test primitive_metrics`
- `python3 tools/kb.py validate`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the changed primitive and knowledge base.
