### PR TITLE
test(shake256): record strict stack boundary

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -2178,7 +2178,8 @@
       "implementation": "src/hashes/shake256/mod.rs",
       "documentation": "src/hashes/shake256/README.md",
       "tests": [
-        "hashes::shake256::tests"
+        "hashes::shake256::tests::hashes_standard_vectors_to_1024_bytes",
+        "hashes::shake256::tests::raw_output_exceeds_strict_stack_limit"
       ],
       "references": [
         "fips-202",
@@ -2199,21 +2200,25 @@
             "output_bytes": 1024,
             "message_bytes_max": 511
           },
-          "includes": "fragment-only: full sponge and squeeze; checked byte metrics not yet recorded",
-          "script_bytes": null,
-          "witness_bytes": null,
-          "witness_bytes_max": null,
-          "max_stack_items": null,
+          "includes": "fragment-with-memory: full sponge and squeeze; message pushes, output comparison, terminal predicate, and witness serialization excluded from script size",
+          "script_bytes": 15927814,
+          "witness_bytes": 65,
+          "witness_bytes_max": 65,
+          "max_stack_items": 1709,
           "executed_opcodes": null,
           "validation_weight": null,
           "setup_script_bytes": null,
           "per_use_script_bytes": null,
-          "metric_keys": []
+          "metric_keys": [
+            "shake256_32_1024",
+            "shake256_witness_32",
+            "shake256_stack_32_1024"
+          ]
         }
       ],
       "limitations": [
         "Output alone exceeds the 1,000-item consensus stack limit",
-        "No metric snapshot yet"
+        "The representative 32-byte input exceeds the 1,000-item stack limit with the complete 1,024-byte output"
       ],
       "open_problems": [
         "OP-003",

--- a/src/hashes/shake256/mod.rs
+++ b/src/hashes/shake256/mod.rs
@@ -447,7 +447,9 @@ mod tests {
     use super::*;
     use crate::{
         arithmetic::u32::xor::u8_push_xor_table,
-        support::execution::execute_script_without_stack_limit,
+        support::execution::{
+            execute_script_with_inputs_strict, execute_script_without_stack_limit,
+        },
     };
 
     fn push_message(message: &[u8]) -> Script {
@@ -602,5 +604,18 @@ mod tests {
     #[test]
     fn rejects_unsupported_message_length() {
         assert!(std::panic::catch_unwind(|| shake256(512)).is_err());
+    }
+
+    #[test]
+    fn raw_output_exceeds_strict_stack_limit() {
+        let result = execute_script_with_inputs_strict(script! {{ shake256(0) }}, vec![]);
+        assert!(
+            !result.success,
+            "raw SHAKE256 output unexpectedly passed: {result}"
+        );
+        assert!(
+            result.stats.max_nb_stack_items >= 1_000,
+            "strict execution stopped before the stack boundary: {result}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a strict tapscript execution test proving raw SHAKE256 output exceeds the 1,000-item combined stack limit
- replace the stale catalog placeholder with the measured 32-byte configuration
- record the existing script, witness, and stack metrics in the catalog

## Validation
- `cargo test --locked hashes::shake256::tests`
- `python3 tools/kb.py validate`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the changed primitive and knowledge base.
