### PR TITLE
feat(hashes): add HASH160 composition

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1728,6 +1728,67 @@
       ]
     },
     {
+      "id": "hash/hash160-u32",
+      "name": "HASH160 over byte-oriented u32 hashes",
+      "class": "hash/fixed",
+      "summary": "Bitcoin HASH160 composition using SHA-256 followed by RIPEMD-160 over byte-valued stack items.",
+      "status": "compatibility",
+      "evidence": "differentially-validated",
+      "execution": "research-unlimited",
+      "as_of": "2026-09-11",
+      "knowledge_page": "knowledge/primitives/hash160.md",
+      "implementation": "src/hashes/hash160/mod.rs",
+      "documentation": "src/hashes/hash160/README.md",
+      "tests": [
+        "hashes::hash160::tests::matches_reference_vectors",
+        "hashes::hash160::tests::rejects_unsupported_message_length"
+      ],
+      "references": [
+        "bitcoin-core-v29-hashes",
+        "bitcoin-scriptexec-locked"
+      ],
+      "techniques": [
+        "composition",
+        "digit-arithmetic",
+        "lookup-table"
+      ],
+      "security": "HASH160 inherits SHA-256 preimage behavior and RIPEMD-160's 160-bit output and approximately 80-bit generic collision bound; the composition itself does not add authentication beyond the caller's digest check.",
+      "stack_contract": "Consumes one item per message byte and returns 20 byte items with the first digest byte on top.",
+      "configurations": [
+        {
+          "id": "message-32",
+          "label": "32-byte input",
+          "parameters": {
+            "message_bytes": 32,
+            "intermediate_representation": "32 byte-valued stack items"
+          },
+          "includes": "fragment-with-memory: SHA-256 and RIPEMD-160 fragments with table setup and cleanup; excludes message pushes, digest comparison, and witness serialization",
+          "script_bytes": 756491,
+          "witness_bytes": 65,
+          "witness_bytes_max": 65,
+          "max_stack_items": 856,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": null,
+          "per_use_script_bytes": 756491,
+          "metric_keys": [
+            "hash160_32",
+            "hash160_witness_32",
+            "hash160_stack_32"
+          ]
+        }
+      ],
+      "limitations": [
+        "Messages are limited to 511 bytes and fixed at script-generation time",
+        "The representative script exceeds the repository optimizer cutoff and is reported unoptimized",
+        "Bitcoin Core consensus and relay-policy validation were not performed"
+      ],
+      "open_problems": [
+        "OP-001",
+        "OP-003"
+      ]
+    },
+    {
       "id": "hash/sha1-u32",
       "name": "SHA-1 over u32 bytes",
       "class": "hash/fixed",

--- a/knowledge/comparisons/hashes.md
+++ b/knowledge/comparisons/hashes.md
@@ -8,6 +8,7 @@ Measured fragments exclude input pushes and output comparison.
 | BLAKE3 limb29 | 64-byte input | 72,293 | differentially-validated | Single 1,024-byte chunk only; includes table memory |
 | SHA-1 u32 | 32-byte input | 209,726 | differentially-validated | Collision-broken compatibility hash |
 | RIPEMD-160 u32 | 32-byte input | 244,063 | differentially-validated | 160-bit output |
+| HASH160 SHA-256 → RIPEMD-160 | 32-byte input | 756,491 | differentially-validated | Large composed research fragment |
 | SHA-256 u4 | 32-byte input | 332,942 | differentially-validated | Large research fragment |
 | SHA-256 u32 | 32-byte input | 512,428 | differentially-validated | Larger than local u4 variant |
 | SHAKE256 byte | 32-byte input, 1,024-byte output | 15,927,814 | locally-reproduced | Raw output exceeds 1,000 items |

--- a/knowledge/primitives/hash160.md
+++ b/knowledge/primitives/hash160.md
@@ -1,0 +1,21 @@
+# HASH160 composition
+
+This primitive composes the local byte-oriented SHA-256 and RIPEMD-160
+implementations as `RIPEMD160(SHA256(message))`, matching Bitcoin's HASH160
+construction.
+
+- **Evidence:** `differentially-validated`; empty, `abc`, and both 55/56-byte
+  padding boundaries are checked against the `bitcoin` hash implementations.
+- **Deployment:** `unclassified`; the representative composition passes the
+  local 1,000-item stack check, but it has not been compared with Bitcoin Core
+  consensus or relay-policy execution.
+- **Stack contract:** consumes one byte-valued item per input byte and leaves
+  20 digest bytes with the first byte on top.
+- **Representative cost:** the 32-byte configuration is recorded in the
+  implementation README and catalog. It includes both component fragments but
+  excludes message pushes and output comparison.
+
+The intermediate SHA-256 digest remains in the same byte-item representation
+expected by RIPEMD-160, so the composition does not add a serialization or
+byte-order adapter. Callers still need to bind the digest and enforce their
+terminal clean-stack predicate.

--- a/src/hashes/hash160/README.md
+++ b/src/hashes/hash160/README.md
@@ -1,0 +1,33 @@
+# HASH160
+
+This module composes the repository's byte-oriented SHA-256 and RIPEMD-160
+fragments into Bitcoin's `HASH160(x) = RIPEMD160(SHA256(x))` construction.
+
+## Script metrics
+
+The metric covers both hashing fragments and their table setup/cleanup. Message
+pushes, digest comparison, and witness serialization are excluded from the
+locking-script size. The measured peak is the combined main and alt stack.
+
+| Configuration | Locking script | Unlocking witness | Maximum stack items |
+| --- | ---: | ---: | ---: |
+| 32-byte input | <!-- metric:hash160_32 -->756491<!-- /metric:hash160_32 --> bytes | <!-- metric:hash160_witness_32 -->65<!-- /metric:hash160_witness_32 --> bytes | <!-- metric:hash160_stack_32 -->856<!-- /metric:hash160_stack_32 --> |
+
+The SHA-256 and RIPEMD-160 stages both use byte-valued stack items. The
+intermediate 32-byte SHA-256 digest is consumed directly by RIPEMD-160, so no
+host-side serialization or representation conversion is needed.
+
+The representative script exceeds the repository optimizer's 32 KiB input
+cutoff and is reported unoptimized. Its measured 856-item peak fits under the
+local 1,000-item combined-stack check, but Bitcoin Core consensus and policy
+validation have not been performed.
+
+## Stack contract
+
+`hash160(num_bytes)` consumes exactly `num_bytes` byte-valued main-stack items
+and leaves the 20 RIPEMD-160 digest bytes with the first digest byte on top.
+The message length is fixed at generation time and follows the 511-byte limit
+of the component hash fragments.
+
+The fragment does not compare the digest or append a clean-stack predicate;
+callers must provide the terminal protocol check.

--- a/src/hashes/hash160/mod.rs
+++ b/src/hashes/hash160/mod.rs
@@ -1,0 +1,62 @@
+//! HASH160 composition: RIPEMD-160(SHA-256(message)).
+
+use crate::{
+    hashes::{ripemd160, sha256::sha2_u32},
+    support::script::{script, Script},
+};
+
+/// Hashes a fixed-length byte message with Bitcoin's HASH160 construction.
+///
+/// The message bytes are consumed from the main stack and the 20 digest bytes
+/// remain on the main stack with the first digest byte on top.
+pub fn hash160(num_bytes: usize) -> Script {
+    script! {
+        { sha2_u32::sha256(num_bytes) }
+        { ripemd160::ripemd160(32) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::hashes::{ripemd160 as reference_ripemd160, sha256 as reference_sha256, Hash};
+
+    fn push_message(message: &[u8]) -> Script {
+        script! {
+            for byte in message.iter().rev() {
+                { *byte }
+            }
+        }
+    }
+
+    fn verify_hash160(message: &[u8]) {
+        let sha256 = reference_sha256::Hash::hash(message);
+        let expected = reference_ripemd160::Hash::hash(sha256.as_ref()).to_byte_array();
+        let result = crate::support::execution::execute_script_with_inputs_strict(
+            script! {
+                { push_message(message) }
+                { hash160(message.len()) }
+                for byte in expected {
+                    { byte }
+                    OP_EQUALVERIFY
+                }
+                OP_TRUE
+            },
+            vec![],
+        );
+        assert!(result.success, "{result}");
+    }
+
+    #[test]
+    fn matches_reference_vectors() {
+        verify_hash160(b"");
+        verify_hash160(b"abc");
+        verify_hash160(&[0x42; 55]);
+        verify_hash160(&[0x24; 56]);
+    }
+
+    #[test]
+    fn rejects_unsupported_message_length() {
+        assert!(std::panic::catch_unwind(|| hash160(512)).is_err());
+    }
+}

--- a/src/hashes/mod.rs
+++ b/src/hashes/mod.rs
@@ -1,6 +1,7 @@
 //! Hash primitives and their representation-specific implementations.
 
 pub mod blake3;
+pub mod hash160;
 pub mod ripemd160;
 pub mod sha1;
 pub mod sha256;

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -30,7 +30,7 @@ use bitcoin_lab::{
         m31::{qm31::QM31, u31::M31},
         secp256k1::{bigint9 as secp256k1, rns as composable},
     },
-    hashes::{blake3, ripemd160, sha1, sha256, shake256},
+    hashes::{blake3, hash160, ripemd160, sha1, sha256, shake256},
     signatures::{
         hors, lamport, pointlocks, schnorr,
         winternitz::{
@@ -3570,6 +3570,30 @@ fn metrics() -> Vec<Metric> {
             value: script_len(sha256::sha2_u4::sha256(32)),
         },
         Metric {
+            readme: "src/hashes/hash160/README.md",
+            key: "hash160_32",
+            value: script_len(hash160::hash160(32)),
+        },
+        Metric {
+            readme: "src/hashes/hash160/README.md",
+            key: "hash160_witness_32",
+            value: witness_size(&vec![vec![0x42]; 32]),
+        },
+        Metric {
+            readme: "src/hashes/hash160/README.md",
+            key: "hash160_stack_32",
+            value: max_stack_items_strict(
+                script! {
+                    { hash160::hash160(32) }
+                    for _ in 0..20 {
+                        OP_DROP
+                    }
+                    OP_TRUE
+                },
+                vec![vec![0x42]; 32],
+            ),
+        },
+        Metric {
             readme: "src/hashes/shake256/README.md",
             key: "shake256_32_1024",
             value: script_len(shake256::shake256(32)),
@@ -4035,6 +4059,34 @@ fn winternitz20_metrics_are_current() {
 #[test]
 fn prince_metrics_are_current() {
     check_readme_metrics(prince_metrics());
+}
+
+#[test]
+fn hash160_metrics_are_current() {
+    check_readme_metrics(vec![
+        Metric {
+            readme: "src/hashes/hash160/README.md",
+            key: "hash160_32",
+            value: script_len(hash160::hash160(32)),
+        },
+        Metric {
+            readme: "src/hashes/hash160/README.md",
+            key: "hash160_witness_32",
+            value: witness_size(&vec![vec![0x42]; 32]),
+        },
+        Metric {
+            readme: "src/hashes/hash160/README.md",
+            key: "hash160_stack_32",
+            value: max_stack_items_strict(
+                script! {
+                    { hash160::hash160(32) }
+                    for _ in 0..20 { OP_DROP }
+                    OP_TRUE
+                },
+                vec![vec![0x42]; 32],
+            ),
+        },
+    ]);
 }
 
 /// This isolated fixture exercises only the two small packed decoders. It


### PR DESCRIPTION
## Summary
- add a reusable HASH160 adapter that composes the existing byte-oriented SHA-256 and RIPEMD-160 fragments
- verify empty, `abc`, and 55/56-byte padding-boundary vectors against the `bitcoin` hash implementations
- document the 32-byte composition cost and strict local stack peak in the catalog and hash comparison

## Evidence
- script: 756,491 bytes
- witness: 65 bytes for 32 byte-valued inputs
- strict local combined stack peak: 856 items

## Validation
- `cargo test --locked hashes::hash160::tests`
- `cargo test --locked --test primitive_metrics hash160_metrics_are_current`
- `python3 tools/kb.py validate`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the changed primitive and knowledge base.
