### PR TITLE
test(scriptint): cover encoding boundaries

### DIFF
--- a/knowledge/primitives/scriptnum-hinted-div.md
+++ b/knowledge/primitives/scriptnum-hinted-div.md
@@ -8,6 +8,8 @@ constant and derives the Euclidean remainder without `OP_DIV` or `OP_MOD`.
 - **Evidence:** locally reproduced, including wrong-hint rejection.
 - **Trust boundary:** the quotient is hostile witness data and is constrained
   by recomposition and remainder bounds.
+- **Encoding boundary:** the locally reproduced division tests cover the
+  minimal ScriptNum transitions at `127/128`, `255/256`, and `-128/-129`.
 - **Representative result:** `hinted_div_rem(8)` is 13 bytes with a 3–11 byte
   serialized witness in the measured range.
 - **Limitation:** not a general wide-integer division primitive.

--- a/src/arithmetic/scriptint/README.md
+++ b/src/arithmetic/scriptint/README.md
@@ -20,6 +20,11 @@ or `OP_MUL` opcodes.
   Script integers supplied on the stack. Their product and every intermediate
   arithmetic value must also fit the four-byte Script-number domain.
 
+Minimal ScriptNum serialization crosses byte boundaries at `127/128`,
+`255/256`, and `-128/-129`; positive values whose high data bit is set gain a
+sign-preserving byte. These encoding changes do not alter the Euclidean
+division contract. The test suite exercises each boundary explicitly.
+
 ## Script metrics
 
 Sizes are generated locking fragments. Witness sizes use Bitcoin's serialized

--- a/src/arithmetic/scriptint/mod.rs
+++ b/src/arithmetic/scriptint/mod.rs
@@ -146,6 +146,12 @@ mod tests {
                 -1,
                 0,
                 1,
+                -129,
+                -128,
+                127,
+                128,
+                255,
+                256,
                 119,
                 123_459,
                 2_147_483_647,
@@ -154,6 +160,13 @@ mod tests {
             }
         }
         assert_division(-2_147_483_647, 1);
+    }
+
+    #[test]
+    fn preserves_division_across_scriptnum_sign_byte_boundaries() {
+        for dividend in [-129, -128, 127, 128, 255, 256] {
+            assert_division(dividend, 1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- exercise Euclidean division across ScriptNum minimal-encoding transitions at 127/128, 255/256, and -128/-129
- document that sign-byte serialization changes do not change the arithmetic contract
- record the boundary in the primitive knowledge page

## Validation
- `cargo test --locked arithmetic::scriptint::tests`
- `python3 tools/kb.py validate`
- `git diff --check`

The full repository test suite was intentionally not run; validation is scoped to the changed primitive and knowledge base.
