### PR TITLE
feat(hors): record strict witness stack boundary

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -2842,7 +2842,7 @@
       "status": "experimental",
       "evidence": "locally-reproduced",
       "execution": "unclassified",
-      "as_of": "2026-09-01",
+      "as_of": "2026-09-11",
       "knowledge_page": "knowledge/primitives/hors-hash160.md",
       "implementation": "src/signatures/hors/mod.rs",
       "documentation": "src/signatures/hors/README.md",
@@ -2870,19 +2870,21 @@
           "script_bytes": 809,
           "witness_bytes": 280,
           "witness_bytes_max": 280,
-          "max_stack_items": null,
+          "max_stack_items": 50,
           "executed_opcodes": null,
           "validation_weight": null,
           "setup_script_bytes": 0,
           "per_use_script_bytes": 809,
           "metric_keys": [
             "hors_lock_n32_t8",
-            "hors_witness_n32_t8"
+            "hors_witness_n32_t8",
+            "hors_stack_n32_t8"
           ]
         }
       ],
       "limitations": [
         "Message-to-index derivation not implemented",
+        "Out-of-range indices are clamped rather than rejected",
         "One-time key only"
       ],
       "open_problems": [

--- a/knowledge/comparisons/signatures.md
+++ b/knowledge/comparisons/signatures.md
@@ -102,7 +102,7 @@ and nodes. Optional `Preimage16` comparisons follow the hash comparison.
 | Construction | Authenticated object | Script bytes | Witness bytes (zero / upper bound) | Stack peak | Verification work / missing protocol work |
 | --- | --- | ---: | ---: | ---: | --- |
 | Lamport 2-bit | One value in 0..3 | 96 | 11 | not recorded | Reject rather than clamp invalid values |
-| HORS-like n32/t8 | Explicit subset | 809 | 280 | not recorded | Message-to-index derivation |
+| HORS-like n32/t8 | Explicit subset | 809 | 280 / 16 items, 0 hints | 50 strict | Message-to-index derivation; current verifier clamps oversized indices |
 | Legacy Wots32 list-pick | 32-byte message | 4,908 | 1,477 / 1,542 | 143 | 15 hashes for digits below 8, seven otherwise; clamps above-range digits |
 | Legacy Wots32 list-pick + clear | 32-byte message | 4,844 | 1,477 / 1,542 | 143 | Direct checksum reduction; consumes message; terminal predicate excluded |
 | FastWots32 clamped lookup | 32-byte message | 4,465 | 1,476 / 1,542 | 143 | Legacy-style upper saturation; recovers authenticated clamped digits |

--- a/knowledge/primitives/hors-hash160.md
+++ b/knowledge/primitives/hors-hash160.md
@@ -8,9 +8,12 @@ explicit witness indices.
 - **Evidence:** locally reproduced with boundary, ordering, and malformed
   witnesses.
 - **Representative result:** `n=32,t=8` uses 809 script bytes and a 280-byte
-  witness with 32-byte preimages.
+  witness with 32-byte preimages, exactly 16 data items, zero hints, and a
+  strict combined stack peak of 50 items.
 - **Security:** strictly one-time; concrete forgery probability depends on
   parameters, index derivation, disclosures, and HASH160.
+- **Hostile indices:** the current verifier clamps indices above `n - 1`; it
+  does not provide strict range rejection. A caller must bind the index domain.
 - **Research need:** specify and test a complete message-to-subset transform
   before protocol-level signature claims.
 

--- a/src/signatures/hors/README.md
+++ b/src/signatures/hors/README.md
@@ -21,12 +21,24 @@ Serialized witness size includes the witness count and item-length prefixes.
 Maximum depth scales approximately with `n + 2t`; the executable tests include
 the documented `n=32,t=8` case and boundary/malformed cases.
 
+For the representative `n=32,t=8` profile, the witness contains exactly 16
+complete data items and zero auxiliary hints. All 32 committed hashes and all
+16 witness items coexist at script entry. Strict local tapscript execution
+measures a combined main/alt-stack peak of
+`<!-- metric:hors_stack_n32_t8 -->50<!-- /metric:hors_stack_n32_t8 -->`
+items and 88 static non-push opcodes. The pinned executor reports zero for its
+runtime opcode counter in tapscript, so the static count is the available
+opcode measure. This is a local stack-boundary result, not consensus or policy
+deployment validation.
+
 ## Security
 
 One-time only. Concrete forgery probability depends on `n`, `t`, the message-to-
 subset procedure used by the caller, and prior disclosures. HASH160 bounds each
 commitment to at most 80-bit collision and 160-bit preimage resistance. The
-module does not itself derive indices from a message.
+module does not itself derive indices from a message. The current verifier
+clamps an index above `n - 1` with `OP_MIN` rather than rejecting it; callers
+must bind indices to the canonical range before using this fragment.
 
 ## Script compatibility and standardness
 

--- a/src/signatures/hors/mod.rs
+++ b/src/signatures/hors/mod.rs
@@ -203,7 +203,9 @@ fn encode_script_int(v: i64) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::support::execution::{execute_script, execute_script_with_inputs};
+    use crate::support::execution::{
+        execute_script, execute_script_with_inputs, execute_script_with_inputs_strict,
+    };
     use crate::support::script::script;
 
     fn make_preimages(n: usize) -> Vec<Vec<u8>> {
@@ -475,5 +477,39 @@ mod tests {
 
         let result = execute_script_with_inputs(locking, witness);
         assert!(result.success, "HORS large failed: {:?}", result);
+    }
+
+    #[test]
+    fn test_hors_large_witness_coexists_under_strict_stack_limit() {
+        let preimages = make_preimages(32);
+        let public_keys = hors_public_keys(&preimages);
+        let indices = vec![0usize, 4, 9, 13, 17, 21, 25, 31];
+        let locking = hors_locking_script(&public_keys, indices.len());
+        let witness = hors_unlocking_witness(&preimages, &indices);
+
+        assert_eq!(witness.len(), 16);
+        let result = execute_script_with_inputs_strict(locking, witness.clone());
+        assert!(result.success, "strict HORS execution failed: {result}");
+        assert_eq!(result.stats.max_nb_stack_items, 50);
+
+        let mut truncated = witness.clone();
+        truncated.pop();
+        assert!(
+            !execute_script_with_inputs_strict(
+                hors_locking_script(&public_keys, indices.len()),
+                truncated,
+            )
+            .success
+        );
+
+        let mut extra = witness;
+        extra.push(vec![0]);
+        assert!(
+            !execute_script_with_inputs_strict(
+                hors_locking_script(&public_keys, indices.len()),
+                extra,
+            )
+            .success
+        );
     }
 }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -3766,6 +3766,14 @@ fn metrics() -> Vec<Metric> {
             value: witness_size(&hors_witness),
         },
         Metric {
+            readme: "src/signatures/hors/README.md",
+            key: "hors_stack_n32_t8",
+            value: max_stack_items_strict(
+                hors::hors_locking_script(&hors_public_keys, 8),
+                hors_witness.clone(),
+            ),
+        },
+        Metric {
             readme: "src/signatures/pointlocks/README.md",
             key: "pointlock_small_r_script",
             value: script_len(small_r_point_lock),


### PR DESCRIPTION
## Summary

- record the complete `n=32,t=8` HORS witness shape: 16 data items and zero hints
- measure the strict combined main/alt-stack peak at 50 items and 88 static non-push opcodes
- add focused strict-stack, truncated-witness, and extra-witness tests
- document the current oversized-index clamping limitation and update the catalog/comparison

The measurement includes all 32 committed hashes and all 16 witness items at script entry. It uses the pinned tapscript executor with the combined 1,000-item stack limit enabled; this is local execution evidence, not a consensus or policy deployment claim. Runtime opcode count is unavailable in tapscript, so the static non-push count is recorded.

## Validation

- `cargo test --locked --lib signatures::hors::tests`
- `cargo test --locked --test primitive_metrics`
- `python3 tools/kb.py validate`
- `cargo fmt --check`
- `git diff --check`

The full repository test suite was intentionally skipped to keep validation scoped.