### PR TITLE
docs(blake3): record tree composition boundary

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1955,7 +1955,7 @@
       "status": "active",
       "evidence": "differentially-validated",
       "execution": "research-unlimited",
-      "as_of": "2026-09-01",
+      "as_of": "2026-09-11",
       "knowledge_page": "knowledge/primitives/blake3-limb29.md",
       "implementation": "src/hashes/blake3/mod.rs",
       "documentation": "src/hashes/blake3/README.md",
@@ -2058,6 +2058,7 @@
       ],
       "limitations": [
         "Messages limited to one 1,024-byte chunk",
+        "No parent-node compression or multi-chunk tree API",
         "Only unkeyed 32-byte output is implemented",
         "Local witness-input and peak-metric execution disables the stack-limit check; Bitcoin Core consensus and policy validation were not performed",
         "A wholly padded final second input group is ignored and not bound"
@@ -2065,7 +2066,8 @@
       "open_problems": [
         "OP-001",
         "OP-003",
-        "OP-013"
+        "OP-013",
+        "OP-020"
       ]
     },
     {

--- a/knowledge/negative-results/blake3-tree-composition.md
+++ b/knowledge/negative-results/blake3-tree-composition.md
@@ -1,0 +1,42 @@
+# BLAKE3 tree composition boundary
+
+## Question
+
+Can the current Script BLAKE3 construction be extended to messages spanning
+multiple 1,024-byte chunks without first adding a parent-node compression
+primitive?
+
+## Result
+
+No. The public generator accepts at most 1,024 bytes and its block flags only
+cover the chunk path: the first block receives `CHUNK_START`, the final block
+receives `CHUNK_END`, and the one-chunk case receives both. The implementation
+does not expose the BLAKE3 `PARENT` compression that combines two child chaining
+values, nor the binary-tree scheduling needed to reduce multiple chunks to one
+root.
+
+The boundary is locally reproduced by the existing `test_max_length` and
+`test_too_long` tests: a 1,024-byte input reaches the supported path, while a
+1,025-byte input is rejected before script generation. This is an API-boundary
+result, not a claim that multi-chunk BLAKE3 is impossible in Bitcoin Script.
+
+The BLAKE3 specification requires chunk chaining and parent-node compression
+for inputs beyond one chunk. The repository's existing single-chunk fragment
+therefore cannot be priced as a tree verifier by extrapolating its 1,024-byte
+configuration. No script-byte, witness-byte, or stack metric is reported for
+the missing parent primitive.
+
+## Follow-up
+
+Implement a standalone parent compression fragment over two 32-byte child
+chaining values, then compose it with two strict 1,024-byte chunk outputs.
+Close this result only when the parent and two-chunk root match the pinned BLAKE3
+reference vectors, reject malformed child-word encodings and extra witness
+items, and report the complete tree's script, witness, and combined-stack
+metrics under the repository execution class.
+
+Evidence is `locally-reproduced` for the current length boundary and
+`inspected` for the missing tree API. Deployment remains `unclassified` for
+the absent construction.
+
+Primary source: `blake3-spec` in `knowledge/references/sources.json`.

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,13 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+
+## NR-044: The current BLAKE3 fragment stops at one chunk
+
+The public BLAKE3 generator accepts at most 1,024 bytes. Its existing block
+flags implement chunk compression but expose no `PARENT` compression or binary
+tree scheduler, so a 1,025-byte message is rejected rather than priced as a
+multi-chunk tree. The existing boundary tests reproduce acceptance at exactly
+1,024 bytes and rejection at 1,025 bytes. This is a
+`locally-reproduced` API boundary and `inspected` missing-construction result,
+not an impossibility claim; the follow-up criterion is recorded in OP-020.

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -282,6 +282,17 @@ lengths and malformed inputs; and it either beats 59,529 bytes below the
 1,000-item peak or records a machine-checkable lower bound for that search
 space.
 
+## OP-020 — BLAKE3 parent-tree composition
+
+Add a standalone `PARENT` compression fragment over two 32-byte child chaining
+values and compose it with at least two strict 1,024-byte chunk outputs.
+**Complete when:** parent and two-chunk root outputs match pinned BLAKE3
+reference vectors; malformed child-word encodings and extra witness items are
+rejected; the complete tree reports locking-script bytes, serialized witness
+bytes, static/executed opcode evidence where available, and combined main/alt
+stack peaks; and the result is labeled with its actual consensus/policy
+execution class rather than inherited from the current single-chunk fragment.
+
 ## OP-014 — Total-domain ScriptNum right-shift frontier
 
 Determine whether a one-item ScriptNum representation can beat the four-byte

--- a/knowledge/primitives/blake3-limb29.md
+++ b/knowledge/primitives/blake3-limb29.md
@@ -29,6 +29,19 @@ bytes, the second 256-bit input group is outside the declared message and is
 dropped without validation before zero padding is synthesized; callers must
 not rely on that ignored group being bound.
 
+## Tree boundary
+
+This implementation is intentionally a single-chunk construction. The public
+generator accepts at most 1,024 bytes, and its block-flag schedule has no
+`PARENT` compression or binary-tree reduction. The boundary is locally
+reproduced by the exact-length test at 1,024 bytes and the rejection test at
+1,025 bytes. A multi-chunk BLAKE3 result must not be estimated by multiplying
+the single-chunk metrics: parent-node compression, child chaining-value
+routing, and the final root schedule have not been implemented or measured.
+
+See the [tree-composition boundary](../negative-results/blake3-tree-composition.md)
+for the falsifiable follow-up criterion.
+
 See the [implementation README](../../src/hashes/blake3/README.md) and catalog
 record `hash/blake3-limb29`. Messages of at most 32 bytes can instead use the
 [sparse direct-u4 profile](blake3-short-u4.md), which removes the selected-limb


### PR DESCRIPTION
## Summary
- record the locally reproduced 1,024-byte support boundary and 1,025-byte rejection
- document that the current Script construction has no `PARENT` compression or multi-chunk tree scheduler
- add NR-044 and OP-020 with a falsifiable parent-tree implementation criterion

## Validation
- `cargo test --locked --lib hashes::blake3::tests::test_max_length` (1 passed)
- `cargo test --locked --lib hashes::blake3::tests::test_too_long` (1 passed)
- `python3 tools/kb.py validate`
- `cargo fmt --check`
- `git diff --check`
- full repository test skipped as requested