### PR TITLE
docs(blake3): record XOF output boundary

### DIFF
--- a/examples/blake3_xof_boundary.rs
+++ b/examples/blake3_xof_boundary.rs
@@ -1,0 +1,15 @@
+use bitcoin_lab::hashes::blake3::blake3_compute_script;
+use bitcoin_lab::support::script::ScriptCompilation;
+
+fn main() {
+    let message: Vec<u8> = (0..32).collect();
+    let mut xof = blake3::Hasher::new().update(&message).finalize_xof();
+    let mut output = [0u8; 64];
+    xof.fill(&mut output);
+    assert_eq!(&output[..32], blake3::hash(&message).as_bytes());
+    println!(
+        "message_bytes=32 reference_xof_bytes={} current_output_contract_bytes=32 current_compute_script_bytes={}",
+        output.len(),
+        blake3_compute_script(32).compile_with_policy().len()
+    );
+}

--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -2059,13 +2059,15 @@
       "limitations": [
         "Messages limited to one 1,024-byte chunk",
         "Only unkeyed 32-byte output is implemented",
+        "BLAKE3 XOF output-block counter is not implemented",
         "Local witness-input and peak-metric execution disables the stack-limit check; Bitcoin Core consensus and policy validation were not performed",
         "A wholly padded final second input group is ignored and not bound"
       ],
       "open_problems": [
         "OP-001",
         "OP-003",
-        "OP-013"
+        "OP-013",
+        "OP-022"
       ]
     },
     {
@@ -2156,13 +2158,15 @@
       "limitations": [
         "Messages are limited to 32 bytes and the length is fixed when the script is generated",
         "Only unkeyed 32-byte output is implemented",
+        "BLAKE3 XOF output-block counter is not implemented",
         "The direct u4 layout uses up to 64 witness items and differs from the selected-limb API",
         "Bitcoin Core consensus and policy validation were not performed"
       ],
       "open_problems": [
         "OP-001",
         "OP-003",
-        "OP-013"
+        "OP-013",
+        "OP-022"
       ]
     },
     {

--- a/knowledge/negative-results/blake3-xof-output.md
+++ b/knowledge/negative-results/blake3-xof-output.md
@@ -1,0 +1,22 @@
+# BLAKE3 XOF output boundary
+
+The local BLAKE3 generators implement the unkeyed 32-byte digest only. They do
+not expose the root output-block counter needed to continue the BLAKE3 XOF
+stream. The independent `blake3` crate produces 64 bytes for the same 32-byte
+message, while the local API fixes the output contract at 32 bytes.
+
+The reproducible probe is:
+
+```sh
+cargo run --locked --example blake3_xof_boundary
+```
+
+It records the 64-byte reference XOF request and the current 32-byte local
+contract. On the pinned local generator, the 32-byte message profile is 65,167
+policy-produced script bytes. This result does not claim that a 64-byte
+extension is impossible.
+Adding XOF output requires pricing the additional root-output compression,
+output routing, cleanup, and stack coexistence under a stated output length.
+
+Evidence: `locally-reproduced`; deployment: `research-unlimited` for the
+existing fragment.

--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -1226,3 +1226,15 @@ selector and then unwrap-panics. A dedicated test reproduces that panic;
 it must not be counted as a clean local rejection or Core validation.
 Negative and larger positive indices are tested separately. This executor
 limitation and missing complete-protocol validation remain under OP-009.
+
+## NR-046: BLAKE3 XOF output is outside the current generator contract
+
+The local BLAKE3 generators stop at the unkeyed 32-byte digest and do not
+implement the root-output block counter needed for XOF continuation. A
+deterministic probe over the 32-byte message `00 01 ... 1f` obtains 64 bytes
+from the independent `blake3` crate while the local generator exposes only the
+32-byte output contract. The existing 32-byte compute profile remains the
+priced baseline; this is a missing-composition boundary, not an impossibility
+proof. Reproducing a longer output requires pricing the extra compression,
+routing, cleanup, and combined stack peak. Evidence is `locally-reproduced`;
+see [the probe](../../examples/blake3_xof_boundary.rs) and [OP-022](../open-problems.md#op-022--blake3-xof-output-frontier).

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -643,3 +643,11 @@ clean-stack semantics, stays below 1,000 combined items in a strict schedule,
 matches the standard BLAKE3 digest in a focused execution, and reports a
 policy-produced leaf smaller than the 3,828,057-byte projection with the same 792 entry items
 and exactly 88 hints.
+
+## OP-022 — BLAKE3 XOF output frontier
+
+Price a reusable BLAKE3 root-output continuation beyond the first 32-byte
+digest. **Complete when:** a generation-time output length supports at least a
+64-byte XOF vector, matches the independent BLAKE3 implementation, records the
+additional output-block compression/routing/cleanup and witness shape, and
+passes the combined 1,000-item stack check for the documented composition.

--- a/knowledge/primitives/blake3-limb29.md
+++ b/knowledge/primitives/blake3-limb29.md
@@ -1,5 +1,9 @@
 # BLAKE3 over tracked limbs
 
+The public construction is limited to the unkeyed 32-byte digest. Its missing
+root-output counter and longer-output routing are recorded in the [XOF
+boundary result](../negative-results/blake3-xof-output.md).
+
 Implements BLAKE3 for messages up to one 1,024-byte chunk using tracked-stack
 u4 and bigint machinery.
 

--- a/src/hashes/blake3/README.md
+++ b/src/hashes/blake3/README.md
@@ -14,7 +14,9 @@ Two input profiles are public:
   compatibility wrapper uses 29-bit limbs.
 
 Both profiles implement unkeyed 32-byte hashing only. Keyed mode, derive-key
-mode, XOF output, and the multi-chunk tree API are not implemented.
+mode, XOF output, and the multi-chunk tree API are not implemented. The
+independent [XOF boundary result](../../knowledge/negative-results/blake3-xof-output.md)
+records the 64-byte reference boundary and the missing output-block schedule.
 
 The experimental `ed25519_challenge` module also exposes custom-signature
 transcript shapes. These are not stable hash APIs and do not implement RFC


### PR DESCRIPTION
## Summary
- add a deterministic probe showing the independent BLAKE3 XOF can produce 64 bytes for a 32-byte message
- record that the local generators expose only the unkeyed 32-byte output contract
- add NR-046 and OP-022 with the missing output-block schedule and acceptance criteria

## Validation
- `cargo run --locked --example blake3_xof_boundary`
- `cargo test --locked --lib hashes::blake3::tests::test_official_test_vectors`
- `python3 tools/kb.py validate`
- `cargo fmt --check`
- `git diff --check`

The full repository test suite was not run; this is a scoped research/documentation contribution.