### PR TITLE
feat(sha1): add output prefix adapter

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1740,7 +1740,9 @@
       "implementation": "src/hashes/sha1/mod.rs",
       "documentation": "src/hashes/sha1/README.md",
       "tests": [
-        "hashes::sha1::tests::hashes_standard_vectors"
+        "hashes::sha1::tests::hashes_standard_vectors",
+        "hashes::sha1::tests::hashes_output_prefixes",
+        "hashes::sha1::tests::rejects_prefix_boundaries"
       ],
       "references": [
         "fips-180-4",
@@ -1770,6 +1772,26 @@
           "per_use_script_bytes": 209726,
           "metric_keys": [
             "sha1_u32_32"
+          ]
+        },
+        {
+          "id": "message32-prefix8",
+          "label": "32-byte input, first 8 digest bytes",
+          "parameters": {
+            "message_bytes": 32,
+            "output_bytes": 8
+          },
+          "includes": "fragment-only: SHA-1 hashing plus output-prefix adapter; excludes message pushes and digest comparison",
+          "script_bytes": 209754,
+          "witness_bytes": null,
+          "witness_bytes_max": null,
+          "max_stack_items": null,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": null,
+          "per_use_script_bytes": 209754,
+          "metric_keys": [
+            "sha1_u32_prefix_32_8"
           ]
         }
       ],

--- a/knowledge/comparisons/hashes.md
+++ b/knowledge/comparisons/hashes.md
@@ -7,6 +7,7 @@ Measured fragments exclude input pushes and output comparison.
 | BLAKE3 sparse direct u4 | 32-byte input | 59,529 | differentially-validated | Fixed length at generation time; at most 32 bytes |
 | BLAKE3 limb29 | 64-byte input | 72,293 | differentially-validated | Single 1,024-byte chunk only; includes table memory |
 | SHA-1 u32 | 32-byte input | 209,726 | differentially-validated | Collision-broken compatibility hash |
+| SHA-1 u32 prefix | 32-byte input, 8-byte prefix | 209,754 | differentially-validated | Collision-broken; adapter does not reduce compression cost |
 | RIPEMD-160 u32 | 32-byte input | 244,063 | differentially-validated | 160-bit output |
 | SHA-256 u4 | 32-byte input | 332,942 | differentially-validated | Large research fragment |
 | SHA-256 u32 | 32-byte input | 512,428 | differentially-validated | Larger than local u4 variant |

--- a/knowledge/primitives/sha1-u32.md
+++ b/knowledge/primitives/sha1-u32.md
@@ -1,7 +1,8 @@
 # SHA-1 over u32 bytes
 
 Implements SHA-1 with byte-oriented u32 operations for fixed messages up to 511
-bytes.
+bytes. `sha1_prefix` provides a generation-time adapter for retaining only the
+first 1..=20 digest bytes.
 
 - **Position:** compatibility construction only; it is not suitable where
   collision resistance is required.
@@ -11,6 +12,8 @@ bytes.
 - **Deployment:** operation-heavy research fragment; complete consensus and
   policy feasibility are configuration-dependent and not established here.
 - **Stack contract:** one byte item per input byte; 20 byte items returned.
+- **Prefix adapter:** retains the first requested digest bytes without reducing
+  the SHA-1 compression cost.
 
 See the [implementation README](../../src/hashes/sha1/README.md) and catalog
 record `hash/sha1-u32`.

--- a/src/hashes/sha1/README.md
+++ b/src/hashes/sha1/README.md
@@ -20,6 +20,13 @@ digest comparison.
 | --- | ---: |
 | 32-byte input | <!-- metric:sha1_u32_32 -->209726<!-- /metric:sha1_u32_32 --> bytes |
 
+The output-prefix adapter keeps the full compression schedule and removes the
+unused digest suffix:
+
+| Configuration | Hashing script |
+| --- | ---: |
+| 32-byte input, first 8 digest bytes | <!-- metric:sha1_u32_prefix_32_8 -->209754<!-- /metric:sha1_u32_prefix_32_8 --> bytes |
+
 This fragment exceeds the repository optimizer's 32 KiB input cutoff and is
 reported unoptimized.
 
@@ -56,7 +63,8 @@ value in `0..=255`.
 `sha1(num_bytes)` consumes exactly `num_bytes` main-stack items and leaves the
 20 digest bytes on the main stack with the first digest byte on top. The
 temporary lookup table and message schedule are removed, and the altstack is
-restored to its starting depth.
+restored to its starting depth. `sha1_prefix(num_bytes, output_bytes)` keeps
+the first `1..=20` digest bytes and drops the rest.
 
 ## Operational notes
 

--- a/src/hashes/sha1/mod.rs
+++ b/src/hashes/sha1/mod.rs
@@ -58,6 +58,31 @@ pub fn sha1(num_bytes: usize) -> Script {
     }
 }
 
+/// Hashes `num_bytes` message bytes and leaves the first `output_bytes` digest
+/// bytes on the main stack.
+pub fn sha1_prefix(num_bytes: usize, output_bytes: usize) -> Script {
+    assert!(
+        (1..=20).contains(&output_bytes),
+        "SHA-1 output prefix must contain between 1 and 20 bytes"
+    );
+    if output_bytes == 20 {
+        return sha1(num_bytes);
+    }
+
+    script! {
+        { sha1(num_bytes) }
+        for _ in 0..output_bytes {
+            OP_TOALTSTACK
+        }
+        for _ in 0..20 - output_bytes {
+            OP_DROP
+        }
+        for _ in 0..output_bytes {
+            OP_FROMALTSTACK
+        }
+    }
+}
+
 fn push_reverse_bytes_to_alt(num_bytes: usize) -> Script {
     script! {
         for i in 1..=num_bytes {
@@ -332,6 +357,21 @@ mod tests {
         assert!(result.success, "{result}");
     }
 
+    fn verify_prefix(message: &[u8], output_bytes: usize) {
+        let expected = reference_sha1::Hash::hash(message).to_byte_array();
+        let result = crate::support::execution::execute_script_without_stack_limit(script! {
+            { push_message(message) }
+            { sha1_prefix(message.len(), output_bytes) }
+            for byte in expected[..output_bytes].iter() {
+                { *byte }
+                OP_EQUALVERIFY
+            }
+            OP_TRUE
+        });
+
+        assert!(result.success, "{result}");
+    }
+
     #[test]
     fn round_functions_match_reference() {
         let a = 0x0123_4567u32;
@@ -367,6 +407,24 @@ mod tests {
                 OP_FROMALTSTACK
             });
             assert!(result.success, "{result}");
+        }
+    }
+
+    #[test]
+    fn hashes_output_prefixes() {
+        for output_bytes in [1, 8, 19, 20] {
+            verify_prefix(b"abc", output_bytes);
+        }
+        for message_len in [55, 56, 63, 64] {
+            verify_prefix(&vec![0xa5; message_len], 8);
+        }
+    }
+
+    #[test]
+    fn rejects_prefix_boundaries() {
+        for output_bytes in [0, 21] {
+            let panic = std::panic::catch_unwind(|| sha1_prefix(1, output_bytes));
+            assert!(panic.is_err());
         }
     }
 

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -3560,6 +3560,11 @@ fn metrics() -> Vec<Metric> {
             value: script_len(sha1::sha1(32)),
         },
         Metric {
+            readme: "src/hashes/sha1/README.md",
+            key: "sha1_u32_prefix_32_8",
+            value: script_len(sha1::sha1_prefix(32, 8)),
+        },
+        Metric {
             readme: "src/hashes/sha256/README.md",
             key: "sha2_u32_32",
             value: script_len(sha256::sha2_u32::sha256(32)),


### PR DESCRIPTION
## Summary
- add `sha1_prefix` for retaining a generation-time prefix of the 20-byte SHA-1 digest
- validate 1, 8, 19, and 20-byte prefixes across single- and multi-block boundaries
- record the adapter cost in the SHA-1 documentation, comparison, catalog, and metrics

## Validation
- `cargo test --locked --lib hashes::sha1::tests`
- `cargo test --locked --test primitive_metrics`
- `python3 tools/kb.py validate`
- `cargo fmt --check`
- `git diff --check`

The full repository test suite was not run; this PR is scoped to the compatibility SHA-1 primitive.