### PR TITLE
feat(u32): add checked byte-to-bit adapter

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -263,10 +263,36 @@
           "metric_keys": [
             "u8_logic_table_push"
           ]
+        },
+        {
+          "id": "u32-le-bits",
+          "label": "One u32 word to little-endian bits",
+          "parameters": {
+            "input_bytes": 4,
+            "output_bits": 32,
+            "byte_range_check": true,
+            "bit_order": "least-significant bit of the least-significant byte on top"
+          },
+          "includes": "fragment-only: four numeric byte range checks and bit extraction; excludes witness serialization and terminal predicate",
+          "script_bytes": 520,
+          "witness_bytes": 9,
+          "witness_bytes_max": 9,
+          "max_stack_items": 35,
+          "executed_opcodes": 370,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 520,
+          "metric_keys": [
+            "u32_le_bits",
+            "u32_le_bits_witness",
+            "u32_le_bits_stack",
+            "u32_le_bits_opcodes"
+          ]
         }
       ],
       "limitations": [
         "Boolean table consumes 256 persistent items",
+        "Bit conversion checks numeric byte range but not byte-unique ScriptNum encoding",
         "Not validated against Bitcoin Core"
       ],
       "open_problems": [

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| One checked u32 word to little-endian bits | u32 byte splitter | 520 | 9-byte witness; 35-item peak; numeric byte range only |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |
@@ -33,6 +34,13 @@ but longer expressions remain modular unless their bound is proved below its
 513-bit composite modulus. Range checks and conversion remain outside a row
 unless its boundary says otherwise; terminal predicates remain excluded from
 both modular-product rows.
+
+The signed-window decoder is a narrow scheduling primitive rather than a
+general field representation. At 32 digits its shared 156-item table saves 564
+bytes over checked conditional extraction, but raises the peak from 194 to 348
+items. The deterministic sweep measures the table at 643 bytes versus 607 for
+the branch baseline at eight digits, and 1,051 versus 1,215 at sixteen; short
+or stack-constrained callers should keep the branch form.
 
 The 9,893-byte Ed25519 row is the current locking-script-size winner for this
 field. It keeps host values in the ordinary field domain but uses a unique

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -9,7 +9,8 @@ stack manipulation.
 - **Evidence:** locally reproduced, including exhaustive byte-level logic tests.
 - **Tradeoff:** operation fragments are moderate, while a reusable Boolean table
   occupies 256 stack items.
-- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39.
+- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39;
+  `u32_to_le_bits` is 520 bytes with a 35-item peak.
 - **Consumers:** SHA-1, SHA-256, RIPEMD-160, and SHAKE256.
 
 See the [implementation README](../../src/arithmetic/u32/README.md),

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -39,6 +39,7 @@ as less-than-or-equal.
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
+| `u32_to_le_bits()` | <!-- metric:u32_le_bits -->520<!-- /metric:u32_le_bits --> bytes | <!-- metric:u32_le_bits_witness -->9<!-- /metric:u32_le_bits_witness --> bytes | <!-- metric:u32_le_bits_stack -->35<!-- /metric:u32_le_bits_stack --> items |
 
 Operand witness serialization is deliberately excluded: callers may construct
 words inside the locking script or supply four witness items per word. No
@@ -68,3 +69,14 @@ caller.
 No hints are required. A witness-supplied word occupies four stack items, most
 significant byte first in the module's normal representation. Binary operation
 inputs and any shared logic table must already be at the documented depths.
+
+## Bit conversion
+
+`u32_to_le_bits()` consumes one u32 word and returns 32 numeric bit items. The
+least-significant byte is on top of the input word; its bit zero is on top of
+the output, followed by bits one through seven and then the next byte. Each
+byte is range-checked numerically against `0..=255`. The 520-byte fragment has
+<!-- metric:u32_le_bits_opcodes -->370<!-- /metric:u32_le_bits_opcodes --> static non-push opcodes and a 35-item local peak with four one-byte witness
+items; it does not establish byte-unique ScriptNum encodings.
+This is a byte-input adapter rather than a replacement for the smaller
+nibble-input table when a caller already owns canonical u4 values.

--- a/src/arithmetic/u32/bits.rs
+++ b/src/arithmetic/u32/bits.rs
@@ -1,0 +1,85 @@
+//! Conversion from a byte-oriented u32 word to a little-endian bit stack.
+
+use super::rotate::u8_extract_1bit;
+use crate::support::script::{script, Script};
+
+/// Converts one byte-oriented u32 word to 32 little-endian bit items.
+///
+/// The input is four numeric byte items with the least-significant byte on
+/// top. The output has bit zero of that byte on top, followed by its higher
+/// bits and then the next byte's bits. Each input byte is checked to be in
+/// `0..=255`; callers that require byte-unique witness encodings must add a
+/// canonical ScriptNum check separately.
+pub fn u32_to_le_bits() -> Script {
+    script! {
+        // Park the four input bytes so the most-significant byte is processed
+        // first while each later byte's bits are left above it.
+        for _ in 0..4 {
+            OP_TOALTSTACK
+        }
+
+        for _ in 0..4 {
+            OP_FROMALTSTACK
+            OP_DUP
+            OP_0
+            256
+            OP_WITHIN
+            OP_VERIFY
+
+            // The extracted bit remains below the shifting byte. This leaves
+            // bits in MSB-to-LSB stack order, so the final LSB is on top.
+            for _ in 0..8 {
+                { u8_extract_1bit() }
+                OP_SWAP
+            }
+            OP_DROP
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::support::execution::execute_script;
+
+    fn verify_word(bytes: [u8; 4]) {
+        let result = execute_script(script! {
+            for byte in bytes {
+                { byte }
+            }
+            { u32_to_le_bits() }
+            for byte in bytes.iter().rev() {
+                for bit in 0..8 {
+                    { (byte >> bit) & 1 }
+                    OP_EQUALVERIFY
+                }
+            }
+            OP_TRUE
+        });
+        assert!(result.success, "bit conversion failed: {result}");
+    }
+
+    #[test]
+    fn converts_boundary_and_pattern_words() {
+        verify_word([0, 0, 0, 0]);
+        verify_word([0xff, 0xff, 0xff, 0xff]);
+        verify_word([0x80, 0x01, 0xaa, 0x55]);
+        for value in 0..=255 {
+            verify_word([value, !value, 0x3c, 0xc3]);
+        }
+    }
+
+    #[test]
+    fn rejects_non_byte_values() {
+        for invalid in [-1, 256] {
+            let result = execute_script(script! {
+                { invalid }
+                0
+                0
+                0
+                { u32_to_le_bits() }
+            });
+            assert!(!result.success, "accepted invalid byte {invalid}");
+        }
+    }
+}

--- a/src/arithmetic/u32/mod.rs
+++ b/src/arithmetic/u32/mod.rs
@@ -1,5 +1,6 @@
 pub mod add;
 pub mod and;
+pub mod bits;
 pub mod cmp;
 pub mod or;
 pub mod rotate;

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -2119,6 +2119,35 @@ fn metrics() -> Vec<Metric> {
         },
         Metric {
             readme: "src/arithmetic/u32/README.md",
+            key: "u32_le_bits",
+            value: script_len(u32::bits::u32_to_le_bits()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_le_bits_witness",
+            value: witness_size(&vec![vec![0x42]; 4]),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_le_bits_stack",
+            value: max_stack_items(
+                script! {
+                    { u32::bits::u32_to_le_bits() }
+                    for _ in 0..32 {
+                        OP_DROP
+                    }
+                    OP_TRUE
+                },
+                vec![vec![0x42]; 4],
+            ),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_le_bits_opcodes",
+            value: static_non_push_opcodes(u32::bits::u32_to_le_bits()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
             key: "u32_add_drop",
             value: script_len(u32::add::u32_add_drop(0, 1)),
         },


### PR DESCRIPTION
## Summary
- add `u32_to_le_bits()` for four checked byte limbs to 32 little-endian bit items
- reject numeric byte values outside `0..=255` and test all byte values plus boundary patterns
- record the 520-byte / 9-byte witness / 35-item peak / 370-opcode profile

## Validation
- `cargo test --locked arithmetic::u32::bits::tests -- --nocapture`
- `python3 tools/kb.py validate`
- `cargo test --locked --test primitive_metrics`
- `cargo fmt --check`
- `git diff --check`

The full repository test suite was not run.