### PR TITLE
feat(u32): add conditional word selector

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -246,6 +246,29 @@
           ]
         },
         {
+          "id": "conditional-select",
+          "label": "u32_conditional_select()",
+          "parameters": {
+            "condition": "numeric truthiness normalized with OP_0NOTEQUAL",
+            "word_width_bytes": 4
+          },
+          "includes": "fragment-only: condition normalization, whole-word branch selection, and restoration of the selected byte sequence; excludes input pushes, output check, unrelated live state, and transaction context",
+          "script_bytes": 9,
+          "witness_bytes": 10,
+          "witness_bytes_max": 19,
+          "max_stack_items": 9,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": 0,
+          "per_use_script_bytes": 9,
+          "metric_keys": [
+            "u32_conditional_select",
+            "u32_conditional_select_witness_min",
+            "u32_conditional_select_witness_max",
+            "u32_conditional_select_stack"
+          ]
+        },
+        {
           "id": "xor-memory",
           "label": "u8_push_xor_table()",
           "parameters": {

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| u32 conditional word selection | u32 normalized truthy selector | 9 | 10–19-byte witness; 9-item peak |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |
@@ -33,6 +34,13 @@ but longer expressions remain modular unless their bound is proved below its
 513-bit composite modulus. Range checks and conversion remain outside a row
 unless its boundary says otherwise; terminal predicates remain excluded from
 both modular-product rows.
+
+The signed-window decoder is a narrow scheduling primitive rather than a
+general field representation. At 32 digits its shared 156-item table saves 564
+bytes over checked conditional extraction, but raises the peak from 194 to 348
+items. The deterministic sweep measures the table at 643 bytes versus 607 for
+the branch baseline at eight digits, and 1,051 versus 1,215 at sixteen; short
+or stack-constrained callers should keep the branch form.
 
 The 9,893-byte Ed25519 row is the current locking-script-size winner for this
 field. It keeps host values in the ordinary field domain but uses a unique

--- a/knowledge/primitives/u32.md
+++ b/knowledge/primitives/u32.md
@@ -9,7 +9,9 @@ stack manipulation.
 - **Evidence:** locally reproduced, including exhaustive byte-level logic tests.
 - **Tradeoff:** operation fragments are moderate, while a reusable Boolean table
   occupies 256 stack items.
-- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39.
+- **Representative results:** add is 78 bytes; subtract is 77; less-than is 39;
+  conditional selection is 9 bytes with a 10–19-byte nine-item witness and a
+  9-item peak.
 - **Consumers:** SHA-1, SHA-256, RIPEMD-160, and SHAKE256.
 
 See the [implementation README](../../src/arithmetic/u32/README.md),

--- a/src/arithmetic/u32/README.md
+++ b/src/arithmetic/u32/README.md
@@ -18,6 +18,8 @@ they do not use BN254 or any other field modulus.
 - `u32_or(a, b, stack_size)`, like XOR and AND, takes distinct word offsets.
   `stack_size` is one plus the number of u32 words above the shared byte-logic
   table. With exactly two working words, the usual value is `3`.
+- `u32_conditional_select()` consumes `condition | when_true | when_false`,
+  normalizes the condition with `OP_0NOTEQUAL`, and returns one complete word.
 - Stack helpers use whole-word offsets. Rotation helpers additionally take a
   rotation count. There are no implicit parameter defaults.
 
@@ -37,19 +39,24 @@ as less-than-or-equal.
 | `u32_lessthanorequal()` | <!-- metric:u32_lessthanorequal -->61<!-- /metric:u32_lessthanorequal --> bytes | 0 bytes | <!-- metric:u32_lessthanorequal_stack -->13<!-- /metric:u32_lessthanorequal_stack --> items |
 | `u32_or(0, 1, 3)` (table excluded) | <!-- metric:u32_or -->326<!-- /metric:u32_or --> bytes | 0 bytes | <!-- metric:u32_or_stack -->272<!-- /metric:u32_or_stack --> items, including table |
 | `u32_notequal()` | <!-- metric:u32_notequal -->19<!-- /metric:u32_notequal --> bytes | 0 bytes | <!-- metric:u32_notequal_stack -->9<!-- /metric:u32_notequal_stack --> items |
+| `u32_conditional_select()` | <!-- metric:u32_conditional_select -->9<!-- /metric:u32_conditional_select --> bytes | <!-- metric:u32_conditional_select_witness_min -->10<!-- /metric:u32_conditional_select_witness_min -->–<!-- metric:u32_conditional_select_witness_max -->19<!-- /metric:u32_conditional_select_witness_max --> bytes | <!-- metric:u32_conditional_select_stack -->9<!-- /metric:u32_conditional_select_stack --> items |
 | `u8_push_xor_table()` | <!-- metric:u8_logic_table_push -->236<!-- /metric:u8_logic_table_push --> bytes | 0 bytes | 256 table items |
 | `u8_drop_xor_table()` | <!-- metric:u8_logic_table_drop -->128<!-- /metric:u8_logic_table_drop --> bytes | 0 bytes | consumes 256 table items |
 
 Operand witness serialization is deliberately excluded: callers may construct
 words inside the locking script or supply four witness items per word. No
-operation-specific hint is needed. The logic table can be shared by any number
-of XOR, AND, and OR operations in one script.
+operation-specific hint is needed. The conditional selector uses one condition
+item plus two four-byte words, for nine witness items when all inputs come from
+the witness. The logic table can be shared by any number of XOR, AND, and OR
+operations in one script.
 
 ## Security
 
 There is no independent cryptographic security parameter. Arithmetic is exact
 only for byte limbs in `0..=255`; callers accepting adversarial witness values
 must enforce limb range and canonical Script-number encoding where required.
+The conditional selector normalizes any numeric truthy/falsy condition before
+`OP_IF`, so it does not rely on non-minimal tapscript branch values.
 
 ## Script compatibility and standardness
 

--- a/src/arithmetic/u32/stack.rs
+++ b/src/arithmetic/u32/stack.rs
@@ -73,6 +73,24 @@ pub fn u32_fromaltstack() -> Script {
     }
 }
 
+/// Select one complete u32 word using Script truthiness.
+///
+/// Stack before (top first): `condition | when_true | when_false`.
+/// Stack after: the selected word. The condition is consumed; a canonical
+/// boolean is not required because selection follows `OP_IF` semantics.
+pub fn u32_conditional_select() -> Script {
+    script! {
+        OP_0NOTEQUAL
+        OP_IF
+            { u32_toaltstack() }
+            { u32_drop() }
+            { u32_fromaltstack() }
+        OP_ELSE
+            { u32_drop() }
+        OP_ENDIF
+    }
+}
+
 pub fn u32_dup() -> Script {
     script! { OP_4DUP }
 }
@@ -174,6 +192,26 @@ mod tests {
                 { u32_notequal() }
                 { (a != b) as u32 }
                 OP_EQUAL
+            };
+            run(script);
+        }
+    }
+
+    #[test]
+    fn test_u32_conditional_select() {
+        for (condition, expected) in [
+            (0, 0x1122_3344),
+            (1, 0xaabb_ccdd),
+            (2, 0xaabb_ccdd),
+            (-1, 0xaabb_ccdd),
+        ] {
+            let script = script! {
+                { u32_push(0x1122_3344) }
+                { u32_push(0xaabb_ccdd) }
+                { condition }
+                { u32_conditional_select() }
+                { u32_push(expected) }
+                { u32_equal() }
             };
             run(script);
         }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -2230,6 +2230,26 @@ fn metrics() -> Vec<Metric> {
         },
         Metric {
             readme: "src/arithmetic/u32/README.md",
+            key: "u32_conditional_select",
+            value: script_len(u32::stack::u32_conditional_select()),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_conditional_select_witness_min",
+            value: witness_size(&vec![Vec::new(); 9]),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_conditional_select_witness_max",
+            value: witness_size(&vec![vec![1]; 9]),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
+            key: "u32_conditional_select_stack",
+            value: max_stack_items(u32::stack::u32_conditional_select(), vec![vec![1]; 9]),
+        },
+        Metric {
+            readme: "src/arithmetic/u32/README.md",
             key: "u8_logic_table_push",
             value: script_len(u32::xor::u8_push_xor_table()),
         },


### PR DESCRIPTION
## Summary
- add a reusable selector for complete four-byte u32 words
- normalize numeric conditions before the tapscript branch
- document the stack contract and focused metrics

## Verification
- `cargo test --locked arithmetic::u32::stack::tests::test_u32_conditional_select -- --nocapture`
- `cargo test --locked --test primitive_metrics`
- `python3 tools/kb.py validate`
- `cargo fmt --check`
- `git diff --check`

The full repository test suite was intentionally not run.