### PR TITLE
docs(blake3): record derive-key boundary

### DIFF
--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -3,6 +3,28 @@
 These records prevent repeated dead ends. They are scoped observations, not
 universal impossibility proofs.
 
+## NR-044: BLAKE3 derive-key mode is not a drop-in unkeyed extension
+
+The local BLAKE3 backend implements the unkeyed mode with the fixed BLAKE3 IV,
+unkeyed flags, and one message-hashing schedule. The reference specification
+defines derive-key mode as two distinct phases: hash the context under
+`DERIVE_KEY_CONTEXT`, then hash the material under `DERIVE_KEY_MATERIAL` using
+the context digest as the chaining key. Prepending the context to the material
+or merely changing the final flags therefore does not implement the mode.
+
+An inspection of `src/hashes/blake3/mod.rs` and its compression helper found no
+API for a runtime context, a derived chaining value, or mode-specific flags;
+the README explicitly limits the implementation to unkeyed 32-byte output.
+No partial derive-key port is retained because it would either silently claim
+the wrong domain or duplicate the full compression schedule without a measured
+stack boundary. Evidence: `inspected`, against the
+[BLAKE3 specification and reference implementation](https://github.com/BLAKE3-team/BLAKE3).
+
+This is a scope boundary, not a claim that derive-key mode cannot fit. A future
+implementation must match official context/material vectors, report both
+compression phases and their mode flags, and measure the derived-key boundary
+under the combined 1,000-item stack limit.
+
 ## NR-037: PRINCEv2 shared-selector corrections outweigh memory savings
 
 The [PRINCEv2 layout search](princev2-layout.md) records the discarded shared

--- a/knowledge/open-problems.md
+++ b/knowledge/open-problems.md
@@ -3,6 +3,16 @@
 Each problem has a falsifiable completion criterion. Update comparisons and
 negative results when closing one.
 
+## OP-020 — BLAKE3 derive-key boundary
+
+Add a mode-correct derive-key construction to the tracked-stack BLAKE3 backend.
+**Complete when:** a deterministic implementation matches the official
+context/material vectors for an empty context, a short context, and a
+multi-block context; records both `DERIVE_KEY_CONTEXT` and
+`DERIVE_KEY_MATERIAL` phases, the derived chaining-key handoff, script bytes,
+witness shape, and combined stack peak; and either executes under the 1,000-item
+limit or records a measured negative result. See [NR-044](negative-results/index.md).
+
 ## OP-019 — PRINCEv2 M-hat circuit frontier
 
 Find a smaller repeated M-hat circuit for generation-time-key encryption.


### PR DESCRIPTION
## Summary
- record why derive-key mode is not a drop-in extension of the current unkeyed backend
- capture the required context-hash and derived-key phases
- add OP-020 with a falsifiable implementation and measurement criterion

## Verification
- `python3 tools/kb.py validate`
- `git diff --check`

No full repository test was run; this PR changes knowledge-base documentation only.