### PR TITLE
feat(sha256): add output prefix adapter

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1880,6 +1880,26 @@
           "metric_keys": [
             "sha2_u32_32"
           ]
+        },
+        {
+          "id": "message-32-prefix-8",
+          "label": "32-byte input, first 8 digest bytes",
+          "parameters": {
+            "message_bytes": 32,
+            "output_bytes": 8
+          },
+          "includes": "fragment-only: hashing fragment plus output-prefix cleanup; excludes message pushes and digest comparison",
+          "script_bytes": 512456,
+          "witness_bytes": null,
+          "witness_bytes_max": null,
+          "max_stack_items": null,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": null,
+          "per_use_script_bytes": 512456,
+          "metric_keys": [
+            "sha2_u32_prefix_32_8"
+          ]
         }
       ],
       "limitations": [

--- a/knowledge/comparisons/hashes.md
+++ b/knowledge/comparisons/hashes.md
@@ -10,6 +10,7 @@ Measured fragments exclude input pushes and output comparison.
 | RIPEMD-160 u32 | 32-byte input | 244,063 | differentially-validated | 160-bit output |
 | SHA-256 u4 | 32-byte input | 332,942 | differentially-validated | Large research fragment |
 | SHA-256 u32 | 32-byte input | 512,428 | differentially-validated | Larger than local u4 variant |
+| SHA-256 u32 prefix | 32-byte input, 8-byte prefix | 512,456 | differentially-validated | Adapter does not reduce compression cost |
 | SHAKE256 byte | 32-byte input, 1,024-byte output | 15,927,814 | locally-reproduced | Raw output exceeds 1,000 items |
 
 BLAKE3's 64-byte row is not directly comparable with the 32-byte hash rows

--- a/knowledge/primitives/sha256-u32.md
+++ b/knowledge/primitives/sha256-u32.md
@@ -2,6 +2,8 @@
 
 Implements SHA-256 using four byte-valued items per word and a shared Boolean
 lookup table.
+`sha256_prefix` provides a generation-time adapter for retaining only the
+first 1..=32 digest bytes.
 
 - **Position:** direct byte-oriented construction with representation reuse
   across several local hashes.
@@ -9,6 +11,8 @@ lookup table.
   including Bitcoin's genesis header.
 - **Representative result:** 512,428 script bytes for a 32-byte hashing
   fragment.
+- **Prefix adapter:** drops the unused digest suffix without reducing the
+  SHA-256 compression cost.
 - **Tradeoff:** larger than the measured u4 construction for the same input,
   but interoperates directly with the u32 backend.
 - **Deployment:** very large research fragment; strict feasibility must be

--- a/src/hashes/sha256/README.md
+++ b/src/hashes/sha256/README.md
@@ -9,6 +9,8 @@ the concrete algorithm to SHA-256.
 - Message length is supplied at script-generation time.
 - `sha2_u32`: one byte per stack item internally; optimized paths exist for 32
   and 80 bytes. The documented default is 32 bytes.
+- `sha2_u32::sha256_prefix`: retains the first 1..=32 digest bytes after the
+  complete compression schedule.
 - `sha2_u4`: two nibbles per input byte and optional addition-table use chosen
   from the block count. The documented default is 32 bytes.
 - `sha2_u4_stack`: the tracked-stack generator additionally selects addition
@@ -22,6 +24,7 @@ output comparison.
 | Implementation | 32-byte input script |
 | --- | ---: |
 | `sha2_u32` | <!-- metric:sha2_u32_32 -->512428<!-- /metric:sha2_u32_32 --> bytes |
+| `sha2_u32`, first 8 digest bytes | <!-- metric:sha2_u32_prefix_32_8 -->512456<!-- /metric:sha2_u32_prefix_32_8 --> bytes |
 | `sha2_u4` | <!-- metric:sha2_u4_32 -->332942<!-- /metric:sha2_u4_32 --> bytes |
 
 Both fragments exceed the repository optimizer's 32 KiB input cutoff and are
@@ -43,6 +46,11 @@ The opcode vocabulary is shared by legacy script and tapscript, but the
 generated scripts are large and operation-heavy. Practical use is tapscript or
 research execution; many configurations exceed P2SH/P2WSH/bare policy or
 legacy limits. The caller must append output verification and cleanstack logic.
+
+The `sha256_prefix(num_bytes, output_bytes)` adapter keeps the first
+`1..=32` digest bytes and drops the rest. It does not reduce the compression
+cost; use it only when the surrounding protocol deliberately chooses a
+truncated digest binding.
 
 ## Witness and hints
 

--- a/src/hashes/sha256/sha2_u32.rs
+++ b/src/hashes/sha256/sha2_u32.rs
@@ -68,6 +68,31 @@ pub fn sha256(num_bytes: usize) -> Script {
     }
 }
 
+/// Hashes `num_bytes` message bytes and leaves the first `output_bytes` digest
+/// bytes on the main stack.
+pub fn sha256_prefix(num_bytes: usize, output_bytes: usize) -> Script {
+    assert!(
+        (1..=32).contains(&output_bytes),
+        "SHA-256 output prefix must contain between 1 and 32 bytes"
+    );
+    if output_bytes == 32 {
+        return sha256(num_bytes);
+    }
+
+    script! {
+        { sha256(num_bytes) }
+        for _ in 0..output_bytes {
+            OP_TOALTSTACK
+        }
+        for _ in 0..32 - output_bytes {
+            OP_DROP
+        }
+        for _ in 0..output_bytes {
+            OP_FROMALTSTACK
+        }
+    }
+}
+
 pub fn sha256_32bytes() -> Script {
     script! {
         {push_reverse_bytes_to_alt(32)}
@@ -983,6 +1008,45 @@ mod tests {
         };
         let res = execute_script(script);
         assert!(res.success);
+    }
+
+    fn verify_prefix(message: &[u8], output_bytes: usize) {
+        let expected = Sha256::digest(message);
+        let mut message_script = script! {};
+        for byte in message.iter().rev() {
+            message_script = script! {
+                { message_script }
+                { *byte }
+            };
+        }
+        let result = execute_script(script! {
+            { message_script }
+            { sha256_prefix(message.len(), output_bytes) }
+            for byte in expected[..output_bytes].iter() {
+                { *byte }
+                OP_EQUALVERIFY
+            }
+            OP_TRUE
+        });
+        assert!(result.success, "{result}");
+    }
+
+    #[test]
+    fn hashes_output_prefixes() {
+        for output_bytes in [1, 8, 31, 32] {
+            verify_prefix(b"abc", output_bytes);
+        }
+        for message_len in [55, 56, 63, 64] {
+            verify_prefix(&vec![0xa5; message_len], 8);
+        }
+    }
+
+    #[test]
+    fn rejects_prefix_boundaries() {
+        for output_bytes in [0, 33] {
+            let panic = std::panic::catch_unwind(|| sha256_prefix(1, output_bytes));
+            assert!(panic.is_err());
+        }
     }
 
     #[test]

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -3566,6 +3566,11 @@ fn metrics() -> Vec<Metric> {
         },
         Metric {
             readme: "src/hashes/sha256/README.md",
+            key: "sha2_u32_prefix_32_8",
+            value: script_len(sha256::sha2_u32::sha256_prefix(32, 8)),
+        },
+        Metric {
+            readme: "src/hashes/sha256/README.md",
             key: "sha2_u4_32",
             value: script_len(sha256::sha2_u4::sha256(32)),
         },


### PR DESCRIPTION
## Summary

- add `sha256_prefix` for retaining a generation-time-selected digest prefix
- validate reference outputs across padding boundaries and prefix limits
- record the measured adapter cost in the README, catalog, and hash comparison

## Validation

- `cargo test --locked hashes::sha256::sha2_u32::tests::hashes_output_prefixes -- --nocapture`
- `cargo test --locked hashes::sha256::sha2_u32::tests::rejects_prefix_boundaries -- --nocapture`
- `cargo test --locked --test primitive_metrics`
- `python3 tools/kb.py validate`
- `cargo fmt --check`
- `git diff --check`

The full repository test suite was intentionally not run; the focused primitive and metric checks pass.
