### PR TITLE
feat(sha256): add u4 output prefix adapter

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1904,7 +1904,8 @@
       "implementation": "src/hashes/sha256/sha2_u4.rs",
       "documentation": "src/hashes/sha256/README.md",
       "tests": [
-        "hashes::sha256::sha2_u4::tests::test_sha256_strs"
+        "hashes::sha256::sha2_u4::tests::test_sha256_strs",
+        "hashes::sha256::sha2_u4::tests::test_sha256_prefix"
       ],
       "references": [
         "fips-180-4",
@@ -1935,6 +1936,26 @@
           "per_use_script_bytes": 332942,
           "metric_keys": [
             "sha2_u4_32"
+          ]
+        },
+        {
+          "id": "message-32-prefix-8-nibbles",
+          "label": "32-byte input, 8-nibble output prefix",
+          "parameters": {
+            "message_bytes": 32,
+            "output_nibbles": 8
+          },
+          "includes": "fragment-only: full hash plus output-suffix drop; excludes message pushes and digest comparison",
+          "script_bytes": 332970,
+          "witness_bytes": null,
+          "witness_bytes_max": null,
+          "max_stack_items": null,
+          "executed_opcodes": null,
+          "validation_weight": null,
+          "setup_script_bytes": null,
+          "per_use_script_bytes": 332970,
+          "metric_keys": [
+            "sha2_u4_prefix_32_8"
           ]
         }
       ],

--- a/knowledge/comparisons/hashes.md
+++ b/knowledge/comparisons/hashes.md
@@ -9,6 +9,7 @@ Measured fragments exclude input pushes and output comparison.
 | SHA-1 u32 | 32-byte input | 209,726 | differentially-validated | Collision-broken compatibility hash |
 | RIPEMD-160 u32 | 32-byte input | 244,063 | differentially-validated | 160-bit output |
 | SHA-256 u4 | 32-byte input | 332,942 | differentially-validated | Large research fragment |
+| SHA-256 u4 prefix adapter | 32-byte input, 8-nibble output | 332,970 | differentially-validated | Full hash still executes; output is truncated only after hashing |
 | SHA-256 u32 | 32-byte input | 512,428 | differentially-validated | Larger than local u4 variant |
 | SHAKE256 byte | 32-byte input, 1,024-byte output | 15,927,814 | locally-reproduced | Raw output exceeds 1,000 items |
 
@@ -17,6 +18,9 @@ without fixing message length and full semantics. The short direct-u4 row does
 use a 32-byte input, but its 64-item input representation differs from each
 other backend. For protocol selection, include
 representation conversion, digest comparison, and any state-compression role.
+The SHA-256 u4 prefix adapter is an output-shape helper, not a cheaper
+truncated SHA-256 construction: it evaluates the same full digest and drops
+the unused suffix.
 Its checked generator applies the pinned peephole optimizer to a fixed point;
 the row is `fragment-with-memory` because it owns full lookup-table setup and
 cleanup. The short-profile executor enforces the 1,000-item local limit, but it

--- a/knowledge/primitives/sha256-u4.md
+++ b/knowledge/primitives/sha256-u4.md
@@ -11,6 +11,8 @@ tables, including a tracked-stack generator.
   fragment.
 - **Tradeoff:** digit expansion and table choices increase stack-management
   complexity.
+- **Output adapter:** `sha256_prefix(num_bytes, output_nibbles)` retains a
+  leading digest prefix after the full hash; it does not reduce hash work.
 - **Deployment:** research-oriented; exact table configuration and full stack
   state determine strict feasibility.
 

--- a/src/hashes/sha256/README.md
+++ b/src/hashes/sha256/README.md
@@ -11,6 +11,8 @@ the concrete algorithm to SHA-256.
   and 80 bytes. The documented default is 32 bytes.
 - `sha2_u4`: two nibbles per input byte and optional addition-table use chosen
   from the block count. The documented default is 32 bytes.
+- `sha256_prefix`: the u4 backend can retain a leading digest prefix measured
+  in nibbles after hashing.
 - `sha2_u4_stack`: the tracked-stack generator additionally selects addition
   tables and full/half XOR tables; defaults in its size tests are enabled.
 
@@ -23,6 +25,7 @@ output comparison.
 | --- | ---: |
 | `sha2_u32` | <!-- metric:sha2_u32_32 -->512428<!-- /metric:sha2_u32_32 --> bytes |
 | `sha2_u4` | <!-- metric:sha2_u4_32 -->332942<!-- /metric:sha2_u4_32 --> bytes |
+| `sha256_prefix` (32-byte input, 8-nibble output) | <!-- metric:sha2_u4_prefix_32_8 -->332970<!-- /metric:sha2_u4_prefix_32_8 --> bytes |
 
 Both fragments exceed the repository optimizer's 32 KiB input cutoff and are
 reported unoptimized.
@@ -49,3 +52,7 @@ legacy limits. The caller must append output verification and cleanstack logic.
 No hints are required. `sha2_u32` consumes one stack item per byte;
 `sha2_u4` consumes two canonical nibbles per byte in the order documented by
 the push helpers.
+
+`sha256_prefix` retains the leading digest nibbles and drops the remainder;
+the full hash is still evaluated, so this is an output-shape adapter rather
+than a cheaper truncated-hash implementation.

--- a/src/hashes/sha256/sha2_u4.rs
+++ b/src/hashes/sha256/sha2_u4.rs
@@ -463,6 +463,18 @@ pub fn sha256(num_bytes: u32) -> Script {
     }
 }
 
+/// Hash `num_bytes` and retain only the leading `output_nibbles` digest items.
+///
+/// The returned fragment leaves the selected nibbles in the same order as the
+/// full digest and preserves the caller's altstack depth.
+pub fn sha256_prefix(num_bytes: u32, output_nibbles: u32) -> Script {
+    assert!(output_nibbles <= 64, "SHA-256 has 64 digest nibbles");
+    script! {
+        { sha256(num_bytes) }
+        { u4_drop(64 - output_nibbles) }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -555,6 +567,45 @@ mod tests {
         test_sha256(hex);
         let hex = "7788ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffaaaaaaaaaaaaaaaa001122334455667788";
         test_sha256(hex);
+    }
+
+    #[test]
+    fn test_sha256_prefix() {
+        let hex_in = "48656c6c6f2e";
+        let mut hasher = Sha256::new();
+        hasher.update(Vec::<u8>::from_hex(hex_in).unwrap());
+        let digest = hasher.finalize().to_lower_hex_string();
+
+        for output_nibbles in [0, 1, 8, 63, 64] {
+            let prefix = &digest[..output_nibbles as usize];
+            let script = script! {
+                { u4_hex_to_nibbles(hex_in) }
+                { sha256_prefix(hex_in.len() as u32 / 2, output_nibbles) }
+                { u4_hex_to_nibbles(prefix) }
+                for _ in 0..output_nibbles {
+                    OP_TOALTSTACK
+                }
+                for i in 1..output_nibbles {
+                    { i }
+                    OP_ROLL
+                }
+                for _ in 0..output_nibbles {
+                    OP_FROMALTSTACK
+                    OP_EQUALVERIFY
+                }
+                OP_TRUE
+            };
+            assert!(
+                execute_script(script).success,
+                "prefix length {output_nibbles}"
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "SHA-256 has 64 digest nibbles")]
+    fn test_sha256_prefix_rejects_oversized_output() {
+        sha256_prefix(32, 65);
     }
 
     #[test]

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -3570,6 +3570,11 @@ fn metrics() -> Vec<Metric> {
             value: script_len(sha256::sha2_u4::sha256(32)),
         },
         Metric {
+            readme: "src/hashes/sha256/README.md",
+            key: "sha2_u4_prefix_32_8",
+            value: script_len(sha256::sha2_u4::sha256_prefix(32, 8)),
+        },
+        Metric {
             readme: "src/hashes/shake256/README.md",
             key: "shake256_32_1024",
             value: script_len(shake256::shake256(32)),


### PR DESCRIPTION
## Summary
- add `sha256_prefix` for retaining a leading SHA-256 u4 digest prefix
- validate zero, odd, near-full, and full prefix lengths plus oversized-output rejection
- record the representative metric and knowledge catalog entry

## Validation
- `cargo test --locked hashes::sha256::sha2_u4::tests::test_sha256_prefix -- --nocapture`
- `python3 tools/kb.py validate`
- `cargo test --locked --test primitive_metrics`
- full repository test suite intentionally skipped; the change is scoped to the SHA-256 u4 primitive