### PR TITLE
feat(sha256): add u4 midstate continuation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ ark-std = { version = "0.5.0", default-features = false }
 blake3 = "1.6.1"
 serde_json = "1.0"
 rand_chacha = "0.3.1"
-sha2 = "0.10"
+sha2 = { version = "0.10", features = ["compress"] }
 
 [[bench]]
 name = "winternitz"

--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -1904,7 +1904,9 @@
       "implementation": "src/hashes/sha256/sha2_u4.rs",
       "documentation": "src/hashes/sha256/README.md",
       "tests": [
-        "hashes::sha256::sha2_u4::tests::test_sha256_strs"
+        "hashes::sha256::sha2_u4::tests::test_sha256_strs",
+        "hashes::sha256::sha2_u4::tests::test_sha256_80bytes_from_midstate",
+        "hashes::sha256::sha2_u4::tests::test_sha256_80bytes_from_midstate_has_strict_stack_profile"
       ],
       "references": [
         "fips-180-4",
@@ -1936,10 +1938,41 @@
           "metric_keys": [
             "sha2_u4_32"
           ]
+        },
+        {
+          "id": "midstate-16-suffix",
+          "label": "64-byte prefix midstate plus 16-byte suffix",
+          "parameters": {
+            "prefix_bytes": 64,
+            "suffix_bytes": 16,
+            "total_message_bytes": 80,
+            "suffix_witness_items": 32,
+            "midstate_fixture": "SHA-256 compress of 64 bytes of 0x42"
+          },
+          "includes": "fragment-only: one-block continuation from a caller-supplied midstate; excludes midstate generation, prefix binding, suffix pushes, and digest comparison",
+          "script_bytes": 332830,
+          "witness_bytes": 48,
+          "witness_bytes_max": 48,
+          "max_stack_items": 969,
+          "executed_opcodes": 195219,
+          "validation_weight": null,
+          "setup_script_bytes": null,
+          "per_use_script_bytes": 332830,
+          "opcode_measurement": "static non-push opcode count",
+          "execution_class": "research-unlimited",
+          "strict_stack_limit_test": true,
+          "hint_stack_items": 0,
+          "metric_keys": [
+            "sha2_u4_80_midstate",
+            "sha2_u4_80_midstate_witness",
+            "sha2_u4_80_midstate_stack",
+            "sha2_u4_80_midstate_opcodes"
+          ]
         }
       ],
       "limitations": [
         "Table configuration affects stack peak",
+        "Caller must bind the supplied midstate to the fixed 64-byte prefix",
         "Strict complete-leaf feasibility unclassified"
       ],
       "open_problems": [

--- a/knowledge/comparisons/hashes.md
+++ b/knowledge/comparisons/hashes.md
@@ -9,6 +9,7 @@ Measured fragments exclude input pushes and output comparison.
 | SHA-1 u32 | 32-byte input | 209,726 | differentially-validated | Collision-broken compatibility hash |
 | RIPEMD-160 u32 | 32-byte input | 244,063 | differentially-validated | 160-bit output |
 | SHA-256 u4 | 32-byte input | 332,942 | differentially-validated | Large research fragment |
+| SHA-256 u4 midstate | 64-byte prefix + 16-byte suffix | 332,830 | locally-reproduced | 32 nibble witness items; 969-item peak; caller binds the state |
 | SHA-256 u32 | 32-byte input | 512,428 | differentially-validated | Larger than local u4 variant |
 | SHAKE256 byte | 32-byte input, 1,024-byte output | 15,927,814 | locally-reproduced | Raw output exceeds 1,000 items |
 
@@ -17,6 +18,10 @@ without fixing message length and full semantics. The short direct-u4 row does
 use a 32-byte input, but its 64-item input representation differs from each
 other backend. For protocol selection, include
 representation conversion, digest comparison, and any state-compression role.
+The u4 midstate continuation is smaller than the corresponding u32 boundary
+but carries twice as many suffix witness items and a higher measured stack peak
+(969 versus 856); both require the caller to bind the supplied state to the
+fixed prefix.
 Its checked generator applies the pinned peephole optimizer to a fixed point;
 the row is `fragment-with-memory` because it owns full lookup-table setup and
 cleanup. The short-profile executor enforces the 1,000-item local limit, but it

--- a/knowledge/primitives/sha256-u4.md
+++ b/knowledge/primitives/sha256-u4.md
@@ -9,6 +9,14 @@ tables, including a tracked-stack generator.
   local cross-implementation tests.
 - **Representative result:** 332,942 script bytes for a 32-byte hashing
   fragment.
+- **Midstate boundary:** `sha256_80bytes_from_midstate` continues a fixed
+  64-byte prefix from its eight-word chaining state and consumes a 16-byte
+  suffix as 32 nibble items. The representative fixture measures 332,830
+  script bytes, 48 serialized witness bytes, 969 combined stack items, and
+  195,219 static non-push opcodes.
+- **Evidence:** the continuation is locally reproduced against independent
+  `sha2::compress256` and `Sha256` results; strict local stack execution passes.
+  The caller remains responsible for binding the supplied state to the prefix.
 - **Tradeoff:** digit expansion and table choices increase stack-management
   complexity.
 - **Deployment:** research-oriented; exact table configuration and full stack

--- a/src/hashes/sha256/README.md
+++ b/src/hashes/sha256/README.md
@@ -11,6 +11,9 @@ the concrete algorithm to SHA-256.
   and 80 bytes. The documented default is 32 bytes.
 - `sha2_u4`: two nibbles per input byte and optional addition-table use chosen
   from the block count. The documented default is 32 bytes.
+- `sha256_80bytes_from_midstate`: one fixed 64-byte prefix is represented by a
+  caller-supplied chaining state; the fragment consumes the remaining 16 bytes
+  as 32 u4 witness items.
 - `sha2_u4_stack`: the tracked-stack generator additionally selects addition
   tables and full/half XOR tables; defaults in its size tests are enabled.
 
@@ -24,8 +27,18 @@ output comparison.
 | `sha2_u32` | <!-- metric:sha2_u32_32 -->512428<!-- /metric:sha2_u32_32 --> bytes |
 | `sha2_u4` | <!-- metric:sha2_u4_32 -->332942<!-- /metric:sha2_u4_32 --> bytes |
 
-Both fragments exceed the repository optimizer's 32 KiB input cutoff and are
-reported unoptimized.
+The u4 midstate continuation has a separate fixed-shape boundary:
+
+| Configuration | Locking script | Unlocking witness | Combined peak | Static non-push opcodes |
+| --- | ---: | ---: | ---: | ---: |
+| 64-byte prefix midstate + 16-byte suffix | <!-- metric:sha2_u4_80_midstate -->332830<!-- /metric:sha2_u4_80_midstate --> bytes | <!-- metric:sha2_u4_80_midstate_witness -->48<!-- /metric:sha2_u4_80_midstate_witness --> bytes | <!-- metric:sha2_u4_80_midstate_stack -->969<!-- /metric:sha2_u4_80_midstate_stack --> items | <!-- metric:sha2_u4_80_midstate_opcodes -->195219<!-- /metric:sha2_u4_80_midstate_opcodes --> |
+
+All reported hashing fragments exceed the repository optimizer's 32 KiB input
+cutoff and are reported unoptimized. The midstate row is a research boundary:
+its state is not authenticated against the fixed prefix by the fragment.
+Strict local execution passes at the measured 969-item peak; complete
+deployment remains unclassified because the fragment exceeds ordinary script
+size and policy limits.
 
 Maximum stack depth depends on input length and implementation. The
 `sha2_u4_stack` generator records it with `StackTracker`; executable hash tests
@@ -48,4 +61,5 @@ legacy limits. The caller must append output verification and cleanstack logic.
 
 No hints are required. `sha2_u32` consumes one stack item per byte;
 `sha2_u4` consumes two canonical nibbles per byte in the order documented by
-the push helpers.
+the push helpers. The midstate continuation consumes 32 canonical nibble items,
+and the caller must bind its eight-word state to the intended 64-byte prefix.

--- a/src/hashes/sha256/sha2_u4.rs
+++ b/src/hashes/sha256/sha2_u4.rs
@@ -18,6 +18,10 @@ const INITSTATE: [u32; 8] = [
 ];
 
 pub fn double_padding(num_bytes: u32) -> (Vec<Script>, u32) {
+    double_padding_with_length(num_bytes, num_bytes)
+}
+
+fn double_padding_with_length(num_bytes: u32, total_num_bytes: u32) -> (Vec<Script>, u32) {
     //55 bytes fits in one block
     //56 to 64 requires two block padding
 
@@ -42,7 +46,7 @@ pub fn double_padding(num_bytes: u32) -> (Vec<Script>, u32) {
             for _ in 0..59 {
                 OP_2DUP
             }
-            { u4_number_to_nibble( num_bytes * 8 ) }
+            { u4_number_to_nibble(total_num_bytes * 8) }
         };
 
         chunks += 1;
@@ -56,7 +60,7 @@ pub fn double_padding(num_bytes: u32) -> (Vec<Script>, u32) {
 
         (results, chunks)
     } else {
-        let (script1, _) = padding(num_bytes);
+        let (script1, _) = padding_with_length(num_bytes, total_num_bytes);
         let mut results = Vec::new();
         for _ in 0..(chunks - 1) {
             results.push(script! {});
@@ -67,10 +71,14 @@ pub fn double_padding(num_bytes: u32) -> (Vec<Script>, u32) {
 }
 
 pub fn padding(num_bytes: u32) -> (Script, u32) {
-    let l = (num_bytes * 8) as i32;
-    let mut k = 512 - l - 8 - 32; // heres is usually minus 8, but as
-                                  // there will be never that many bytes to process
-                                  // one u32 will be enough
+    padding_with_length(num_bytes, num_bytes)
+}
+
+fn padding_with_length(num_bytes: u32, total_num_bytes: u32) -> (Script, u32) {
+    let l = (total_num_bytes * 8) as i32;
+    let mut k = 512 - (num_bytes * 8) as i32 - 8 - 32; // heres is usually minus 8, but as
+                                                       // there will be never that many bytes to process
+                                                       // one u32 will be enough
     let mut chunks = 1;
     while k < 0 {
         k += 512;
@@ -258,10 +266,14 @@ fn get_full_w_pos(top_table: u32, i: u32) -> u32 {
 }
 
 pub fn sha256(num_bytes: u32) -> Script {
+    sha256_with_state(num_bytes, num_bytes, INITSTATE)
+}
+
+fn sha256_with_state(num_bytes: u32, total_num_bytes: u32, initial_state: [u32; 8]) -> Script {
     // up to 55 is one block and always supports add table
     // probably up to 68 bytes I can afford to load the add tables for the first chunk (but have I would have to unload it)
 
-    let (mut padding_scripts, chunks) = double_padding(num_bytes);
+    let (mut padding_scripts, chunks) = double_padding_with_length(num_bytes, total_num_bytes);
     let mut bytes_per_chunk: Vec<u32> = Vec::new();
     let mut bytes_remaining = num_bytes;
     while bytes_remaining > 0 {
@@ -343,7 +355,7 @@ pub fn sha256(num_bytes: u32) -> Script {
 
             if c == 0 {
                 //set initial variables a,b,c,d,e,f,g,h
-                for value in INITSTATE.iter() {
+                for value in initial_state.iter() {
                     { u4_number_to_nibble(*value) }
                 }
             } else {
@@ -424,7 +436,7 @@ pub fn sha256(num_bytes: u32) -> Script {
                 // and leave the result on the altstack
                 // first chunk is added with the init state
                 for i in (0..8).rev() {
-                    { u4_number_to_nibble( INITSTATE[i] ) }
+                    { u4_number_to_nibble(initial_state[i]) }
                     { u4_add(8, vec![0, 8], main_loop_offset_add + 8 - ((7-i) as u32 * 8), use_add_table ) }
                 }
             } else {
@@ -463,12 +475,30 @@ pub fn sha256(num_bytes: u32) -> Script {
     }
 }
 
+/// Continue SHA-256 from a caller-supplied midstate over a 16-byte suffix.
+///
+/// The midstate must be the chaining value after the fixed 64-byte prefix.
+/// This fragment does not authenticate that relationship.
+pub fn sha256_80bytes_from_midstate(midstate: [u32; 8]) -> Script {
+    sha256_with_state(16, 80, midstate)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::support::{execution::execute_script, script::script};
+    use crate::support::{
+        execution::{
+            execute_script, execute_script_with_inputs, execute_script_with_inputs_strict,
+        },
+        script::script,
+    };
     use bitcoin::hex::{DisplayHex, FromHex};
-    use sha2::{Digest, Sha256};
+    use sha2::{compress256, Digest, Sha256};
+
+    const MIDSTATE_42X64: [u32; 8] = [
+        0x8aab60bc, 0xcc769b35, 0x02b9786a, 0x434e707f, 0x943ce9ea, 0xd219ae8e, 0xdd54f002,
+        0xdc7dbb82,
+    ];
 
     #[test]
     fn test_sizes() {
@@ -555,6 +585,64 @@ mod tests {
         test_sha256(hex);
         let hex = "7788ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffaaaaaaaaaaaaaaaa001122334455667788";
         test_sha256(hex);
+    }
+
+    #[test]
+    fn test_sha256_80bytes_from_midstate() {
+        let prefix = [0x42u8; 64];
+        let suffix: Vec<u8> = (0..16).collect();
+        let mut midstate = INITSTATE;
+        compress256(&mut midstate, &[prefix.into()]);
+        assert_eq!(midstate, MIDSTATE_42X64);
+        let mut message = prefix.to_vec();
+        message.extend_from_slice(&suffix);
+        let expected = Sha256::digest(message).to_lower_hex_string();
+        let suffix_hex = suffix.to_lower_hex_string();
+        let script = script! {
+            { u4_hex_to_nibbles(&suffix_hex) }
+            { sha256_80bytes_from_midstate(MIDSTATE_42X64) }
+            { u4_hex_to_nibbles(&expected) }
+            for _ in 0..64 {
+                OP_TOALTSTACK
+            }
+            for i in 1..64 {
+                { i }
+                OP_ROLL
+            }
+            for _ in 0..64 {
+                OP_FROMALTSTACK
+                OP_EQUALVERIFY
+            }
+            OP_TRUE
+        };
+        assert!(execute_script(script).success);
+    }
+
+    #[test]
+    fn test_sha256_80bytes_from_midstate_has_strict_stack_profile() {
+        let script = script! {
+            { sha256_80bytes_from_midstate(MIDSTATE_42X64) }
+            { u4_drop(64) }
+            OP_TRUE
+        };
+        let relaxed = execute_script_with_inputs(script.clone(), vec![Vec::new(); 32]);
+        assert!(relaxed.success);
+        assert_eq!(relaxed.stats.max_nb_stack_items, 969);
+        let strict = execute_script_with_inputs_strict(script, vec![Vec::new(); 32]);
+        assert!(strict.success);
+    }
+
+    #[test]
+    fn test_sha256_80bytes_from_midstate_rejects_extra_suffix() {
+        let script = script! {
+            { sha256_80bytes_from_midstate([0; 8]) }
+            { u4_drop(64) }
+            OP_DEPTH
+            OP_0
+            OP_EQUAL
+        };
+        let result = execute_script_with_inputs(script, vec![vec![1]; 34]);
+        assert!(!result.success);
     }
 
     #[test]

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -1332,6 +1332,26 @@ fn winternitz20_metrics() -> Vec<Metric> {
 }
 
 fn metrics() -> Vec<Metric> {
+    let sha2_u4_midstate = [
+        0x8aab60bc, 0xcc769b35, 0x02b9786a, 0x434e707f, 0x943ce9ea, 0xd219ae8e, 0xdd54f002,
+        0xdc7dbb82,
+    ];
+    let sha2_u4_midstate_script = sha256::sha2_u4::sha256_80bytes_from_midstate(sha2_u4_midstate);
+    let sha2_u4_midstate_witness = (0u8..16)
+        .flat_map(|byte| [byte >> 4, byte & 0x0f])
+        .map(|nibble| {
+            if nibble == 0 {
+                Vec::new()
+            } else {
+                vec![nibble]
+            }
+        })
+        .collect::<Vec<_>>();
+    let sha2_u4_midstate_boundary = script! {
+        { sha2_u4_midstate_script.clone() }
+        { u4::stack::u4_drop(64) }
+        OP_TRUE
+    };
     let blake3_message: [u8; 64] = std::array::from_fn(|index| index as u8);
     let blake3_expected = *::blake3::hash(&blake3_message).as_bytes();
     let blake3_push = blake3::blake3_push_message_script_with_limb(&blake3_message, 29);
@@ -3568,6 +3588,29 @@ fn metrics() -> Vec<Metric> {
             readme: "src/hashes/sha256/README.md",
             key: "sha2_u4_32",
             value: script_len(sha256::sha2_u4::sha256(32)),
+        },
+        Metric {
+            readme: "src/hashes/sha256/README.md",
+            key: "sha2_u4_80_midstate",
+            value: script_len(sha2_u4_midstate_script),
+        },
+        Metric {
+            readme: "src/hashes/sha256/README.md",
+            key: "sha2_u4_80_midstate_witness",
+            value: witness_size(&sha2_u4_midstate_witness),
+        },
+        Metric {
+            readme: "src/hashes/sha256/README.md",
+            key: "sha2_u4_80_midstate_stack",
+            value: max_stack_items(
+                sha2_u4_midstate_boundary.clone(),
+                sha2_u4_midstate_witness.clone(),
+            ),
+        },
+        Metric {
+            readme: "src/hashes/sha256/README.md",
+            key: "sha2_u4_80_midstate_opcodes",
+            value: static_non_push_opcodes(sha2_u4_midstate_boundary),
         },
         Metric {
             readme: "src/hashes/shake256/README.md",


### PR DESCRIPTION
## Summary
- add a u4 SHA-256 continuation for a caller-supplied midstate after a fixed 64-byte prefix
- add independent midstate/digest correctness coverage, strict stack coverage, and excess-witness rejection
- record the 332,830-byte fragment, 48-byte witness, 969-item peak, and 195,219 static non-push opcodes

The fragment does not authenticate the supplied state against the prefix; callers must bind that relationship. The measured script exceeds ordinary script-size and policy limits, so deployment remains unclassified.

## Tests
- `python3 tools/kb.py validate`
- `cargo test --locked hashes::sha256::sha2_u4::tests::test_sha256_80bytes_from_midstate -- --nocapture`
- `cargo test --locked --test primitive_metrics` (6 passed, 1 ignored)
- full repository test suite intentionally not run