### PR TITLE
feat(u4): add little-endian bit adapter

### DIFF
--- a/knowledge/catalog.json
+++ b/knowledge/catalog.json
@@ -124,7 +124,7 @@
       "status": "active",
       "evidence": "locally-reproduced",
       "execution": "unclassified",
-      "as_of": "2026-09-01",
+      "as_of": "2026-09-11",
       "knowledge_page": "knowledge/primitives/u4.md",
       "implementation": "src/arithmetic/u4/mod.rs",
       "documentation": "src/arithmetic/u4/README.md",
@@ -143,7 +143,7 @@
         "tracked-stack"
       ],
       "security": "No independent cryptographic claim. Checked bit conversion enforces numeric nibble range before table indexing; unchecked conversion and other u4 operations require callers to supply certified canonical nibbles. Byte-unique ScriptNum encoding remains a protocol obligation where applicable.",
-      "stack_contract": "Values are expanded into four-bit stack digits. The batch bit converter consumes contiguous nibbles, uses a temporary 61-item table, and returns four big-endian bits per input on the main or altstack as selected by the API.",
+      "stack_contract": "Values are expanded into four-bit stack digits. The batch bit converter consumes contiguous nibbles, uses a temporary 61-item table, and returns four bits per input on the main or altstack as selected by the API; the API chooses big- or little-endian bit order within each nibble.",
       "configurations": [
         {
           "id": "addition-memory",
@@ -184,6 +184,34 @@
             "u4_bits_checked_batch32",
             "u4_bits_checked_batch32_stack",
             "u4_bits_checked_batch32_opcodes"
+          ]
+        },
+        {
+          "id": "nibble-to-le-bits-batch32-checked",
+          "label": "Checked 32-nibble staggered-table little-endian decomposition",
+          "parameters": {
+            "nibble_count": 32,
+            "bit_order": "least-significant bit first within each nibble",
+            "check_inputs": true,
+            "table_items": 61,
+            "complete_witness_items": 32,
+            "hint_items": 0
+          },
+          "includes": "fragment-with-memory: 61-item mirrored staggered-table setup, 32 checked queries, table cleanup, and restoration of all 128 output bits to the main stack; witness_bytes reports 32 canonical 0x0f input items; excludes terminal predicate, unrelated live state, and transaction context",
+          "script_bytes": 924,
+          "witness_bytes": 64,
+          "witness_bytes_max": 64,
+          "max_stack_items": 189,
+          "executed_opcodes": 735,
+          "validation_weight": null,
+          "setup_script_bytes": 61,
+          "per_use_script_bytes": 26,
+          "metric_keys": [
+            "u4_bits_le_table_push",
+            "u4_bits_le_checked_batch32",
+            "u4_bits_le_checked_batch32_witness",
+            "u4_bits_le_checked_batch32_stack",
+            "u4_bits_le_checked_batch32_opcodes"
           ]
         }
       ],

--- a/knowledge/comparisons/arithmetic.md
+++ b/knowledge/comparisons/arithmetic.md
@@ -9,6 +9,7 @@ differ. Follow each catalog configuration before comparing numbers.
 | Small-field add | M31 u31 add | 18 | Canonical field input |
 | Small-field variable multiply | M31 u31 multiply | 1,370 | Witness quotient relation |
 | 32 checked nibbles to 128 bits | u4 staggered batch table | 924 | 189-item peak; tapscript-oriented |
+| 32 checked nibbles to 128 little-endian bits | u4 mirrored staggered table | 924 | 64-byte witness; 189-item peak; same table cost, no per-nibble reversal |
 | Wide add | U254 add | 176 | Nine limbs |
 | Wide multiply | U254 multiply | 111,466 | Above optimizer cutoff; unoptimized |
 | Ed25519 ordinary-domain multiply | 51 biased centered radix-32 digits, 13 signed tables | <!-- metric:ed25519_field_mul -->9893<!-- /metric:ed25519_field_mul --> | 245-byte/51-item incremental hint; certified operands; 523-item strict peak |

--- a/knowledge/primitives/u4.md
+++ b/knowledge/primitives/u4.md
@@ -11,13 +11,27 @@ variants. It is a backend for bit-oriented hashes and block ciphers.
 - **Representative results:** addition-table setup is 92 script bytes. A
   checked 32-nibble decomposition is 924 bytes, executes 735 non-push opcodes,
   and peaks at 189 combined stack items; the equal-boundary branch baseline is
-  1,374 bytes and peaks at 130.
+  1,374 bytes and peaks at 130. The little-endian table has the same measured
+  boundary while emitting each nibble's least-significant bit first.
 - **Composition constraint:** table memory and digit-expanded state can dominate
   the 1,000-item stack limit.
 - **Input boundary:** the checked decomposition proves numeric range `0..=15`;
   unchecked lookup requires previously certified nibbles and neither form alone
   proves byte-unique ScriptNum encoding.
-- **Consumers:** u4 SHA-256, AES-128, and PRINCEv2.
+- **Research question:** can a mirrored staggered table emit least-significant
+  bits first without increasing the existing checked converter's script,
+  witness, or stack cost?
+- **Hypothesis and comparison:** the mirrored table should match the
+  big-endian adapter's 61-item setup, 924-byte 32-nibble fragment, and
+  189-item peak, while avoiding a caller-side four-bit reversal composition.
+- **Threat model and execution:** witness nibbles are hostile; checked mode
+  rejects numeric values outside `0..=15`, but callers still own canonical
+  encoding and protocol binding. The result is locally reproduced in the
+  repository's strict tapscript executor and remains `unclassified` for
+  consensus and policy deployment.
+- **Consumers:** u4 SHA-256, AES-128, and PRINCEv2. The little-endian adapter
+  targets ScriptNum and scalar consumers that otherwise need per-nibble bit
+  reversal.
 
 See the [implementation README](../../src/arithmetic/u4/README.md) and catalog
 record `arithmetic/u4`.

--- a/src/arithmetic/u4/README.md
+++ b/src/arithmetic/u4/README.md
@@ -10,8 +10,9 @@ these operations, but this module contains no hash-specific round logic.
   preloaded addition tables are used. There is no universal default.
 - Logic may use full or triangular half tables; shifts and rotations take
   `1..=3` bit counts unless their function documents otherwise.
-- `bits::u4_nibbles_to_be_bits[_toaltstack](nibble_count, check_inputs)` takes
-  an explicit batch size in `1..=234` and has no default for input checking.
+- `bits::u4_nibbles_to_be_bits[_toaltstack](nibble_count, check_inputs)` and
+  `bits::u4_nibbles_to_le_bits[_toaltstack](nibble_count, check_inputs)` take
+  an explicit batch size in `1..=234` and have no default for input checking.
 
 ## Script metrics
 
@@ -21,13 +22,15 @@ setup, all queries, table cleanup, and restoration of 128 output bits to the
 main stack. The branch baseline applies the existing four-bit limb splitter to
 each input with the same output-restoration boundary.
 
-| Fragment | Locking script | Maximum combined stack | Executed non-push opcodes |
+| Fragment | Locking script | Maximum combined stack | Static non-push opcodes |
 | --- | ---: | ---: | ---: |
 | `u4_push_add_tables()` | <!-- metric:u4_add_tables -->92<!-- /metric:u4_add_tables --> bytes | instance-specific | not recorded |
 | Staggered bit-table setup | <!-- metric:u4_bits_table_push -->61<!-- /metric:u4_bits_table_push --> bytes | 61 table items | not recorded |
 | Staggered bit-table cleanup | <!-- metric:u4_bits_table_drop -->31<!-- /metric:u4_bits_table_drop --> bytes | consumes 61 items | not recorded |
 | One checked table query, output on altstack | <!-- metric:u4_bits_checked_query -->22<!-- /metric:u4_bits_checked_query --> bytes | composition-dependent | not recorded |
+| Little-endian staggered bit-table setup | <!-- metric:u4_bits_le_table_push -->61<!-- /metric:u4_bits_le_table_push --> bytes | 61 table items | not recorded |
 | Checked table batch, 32 nibbles | <!-- metric:u4_bits_checked_batch32 -->924<!-- /metric:u4_bits_checked_batch32 --> bytes | <!-- metric:u4_bits_checked_batch32_stack -->189<!-- /metric:u4_bits_checked_batch32_stack --> items | <!-- metric:u4_bits_checked_batch32_opcodes -->735<!-- /metric:u4_bits_checked_batch32_opcodes --> |
+| Checked little-endian table batch, 32 nibbles | <!-- metric:u4_bits_le_checked_batch32 -->924<!-- /metric:u4_bits_le_checked_batch32 --> bytes | <!-- metric:u4_bits_le_checked_batch32_stack -->189<!-- /metric:u4_bits_le_checked_batch32_stack --> items | <!-- metric:u4_bits_le_checked_batch32_opcodes -->735<!-- /metric:u4_bits_le_checked_batch32_opcodes --> |
 | Unchecked table batch, 32 nibbles | <!-- metric:u4_bits_unchecked_batch32 -->764<!-- /metric:u4_bits_unchecked_batch32 --> bytes | 189 items | not recorded |
 | Existing branch splitter, 32 four-bit limbs | <!-- metric:u4_bits_branch_batch32 -->1374<!-- /metric:u4_bits_branch_batch32 --> bytes | <!-- metric:u4_bits_branch_batch32_stack -->130<!-- /metric:u4_bits_branch_batch32_stack --> items | not recorded |
 
@@ -37,6 +40,13 @@ complete checked batch is `92 + 26*n` bytes. The existing branch splitter is
 `43*n` bytes on the same boundary; the checked table wins from six nibbles.
 Unchecked lookup is `92 + 21*n` and wins from five, but is safe only for
 previously certified nibbles.
+
+The little-endian row has the same size and stack profile: it changes only the
+four values stored in each staggered table group. It is intended for callers
+that consume each nibble least-significant-bit first; reversing four output
+bits per nibble after the big-endian adapter is a separate composition cost.
+The representative little-endian witness is 32 canonical `0x0f` stack items,
+serialized as <!-- metric:u4_bits_le_checked_batch32_witness -->64<!-- /metric:u4_bits_le_checked_batch32_witness --> bytes.
 
 ## Security
 
@@ -77,6 +87,11 @@ inputs are consumed and replaced by four bits per nibble. The top input's most
 significant bit is the top output, followed by that nibble's remaining bits and
 then each deeper nibble. The `_toaltstack` variant leaves `preserved` on the
 main stack and all new bits above any pre-existing altstack state.
+
+For `u4_nibbles_to_le_bits(n, ...)`, the stack contract and input order are the
+same, but each nibble's least-significant bit is emitted first. The checked
+32-nibble representative consumes 32 witness data items (64 serialized
+witness bytes for the all-15 fixture); no hint items are required.
 
 The standalone batch peak is `4*n + 61` combined main/alt-stack items. The
 generator rejects `n > 234`, but callers must reduce the batch further for any

--- a/src/arithmetic/u4/bits.rs
+++ b/src/arithmetic/u4/bits.rs
@@ -17,41 +17,59 @@ pub const U4_BITS_TABLE_ITEMS: u32 = 61;
 /// main/alt-stack items. Callers with preserved state must reduce the batch.
 pub const U4_BITS_MAX_BATCH: u32 = (1_000 - U4_BITS_TABLE_ITEMS) / 4;
 
-fn table_value_at_depth(depth: u32) -> u32 {
+fn table_value_at_depth(depth: u32, little_endian: bool) -> u32 {
     if depth == 0 {
         return 0;
     }
 
     let nibble = (depth + 3) / 4;
-    let bit_in_be_order = depth - (4 * nibble - 3);
-    (nibble >> (3 - bit_in_be_order)) & 1
+    let bit_in_nibble = depth - (4 * nibble - 3);
+    let bit = if little_endian {
+        bit_in_nibble
+    } else {
+        3 - bit_in_nibble
+    };
+    (nibble >> bit) & 1
 }
 
-/// Push the 61-item staggered lookup table.
-///
-/// The item at depth `4*x-3 ..= 4*x` is the big-endian bit sequence of
-/// canonical nibble `x` for every `x` in `1..=15`. Depth zero is unused.
-pub fn u4_push_to_be_bits_table() -> Script {
+fn push_to_bits_table(little_endian: bool) -> Script {
     script! {
         for depth in (0..U4_BITS_TABLE_ITEMS).rev() {
-            { table_value_at_depth(depth) }
+            { table_value_at_depth(depth, little_endian) }
         }
     }
 }
 
+/// Push the 61-item staggered big-endian lookup table.
+///
+/// The item at depth `4*x-3 ..= 4*x` is the big-endian bit sequence of
+/// canonical nibble `x` for every `x` in `1..=15`. Depth zero is unused.
+pub fn u4_push_to_be_bits_table() -> Script {
+    push_to_bits_table(false)
+}
+
+/// Push the 61-item staggered little-endian lookup table.
+pub fn u4_push_to_le_bits_table() -> Script {
+    push_to_bits_table(true)
+}
+
+fn drop_bits_table() -> Script {
+    u4_drop(U4_BITS_TABLE_ITEMS)
+}
+
 /// Drop the complete staggered nibble-to-bits table.
 pub fn u4_drop_to_be_bits_table() -> Script {
-    u4_drop(U4_BITS_TABLE_ITEMS)
+    drop_bits_table()
 }
 
 /// Convert one nibble immediately below the table and push its bits to altstack.
 ///
 /// Before: `preserved | nibble | table`, where `table` is the 61-item output of
-/// [`u4_push_to_be_bits_table`]. After: `preserved | table` on the main stack,
-/// with `bit3 | bit2 | bit1 | bit0` newly pushed to the altstack in that order.
-/// When `check_input` is true, the numeric nibble is first constrained to
-/// `0..=15`. When false, the caller must already have established that range;
-/// otherwise `OP_PICK` can address outside the table.
+/// either table-push helper. After: `preserved | table` on the main stack, with
+/// the table's four bits newly pushed to the altstack in table order. When
+/// `check_input` is true, the numeric nibble is first constrained to `0..=15`.
+/// When false, the caller must already have established that range; otherwise
+/// `OP_PICK` can address outside the table.
 pub fn u4_nibble_below_bits_table_toaltstack(check_input: bool) -> Script {
     script! {
         { U4_BITS_TABLE_ITEMS }
@@ -101,7 +119,7 @@ pub fn u4_nibbles_to_be_bits_toaltstack(nibble_count: u32, check_inputs: bool) -
         for _ in 0..nibble_count {
             { u4_nibble_below_bits_table_toaltstack(check_inputs) }
         }
-        { u4_drop_to_be_bits_table() }
+        { drop_bits_table() }
     }
 }
 
@@ -114,6 +132,28 @@ pub fn u4_nibbles_to_be_bits_toaltstack(nibble_count: u32, check_inputs: bool) -
 pub fn u4_nibbles_to_be_bits(nibble_count: u32, check_inputs: bool) -> Script {
     script! {
         { u4_nibbles_to_be_bits_toaltstack(nibble_count, check_inputs) }
+        for _ in 0..4 * nibble_count {
+            OP_FROMALTSTACK
+        }
+    }
+}
+
+/// Consume a contiguous nibble batch and replace it with little-endian bits.
+pub fn u4_nibbles_to_le_bits_toaltstack(nibble_count: u32, check_inputs: bool) -> Script {
+    validate_batch_size(nibble_count);
+    script! {
+        { u4_push_to_le_bits_table() }
+        for _ in 0..nibble_count {
+            { u4_nibble_below_bits_table_toaltstack(check_inputs) }
+        }
+        { drop_bits_table() }
+    }
+}
+
+/// Consume a contiguous nibble batch and replace it with little-endian bits.
+pub fn u4_nibbles_to_le_bits(nibble_count: u32, check_inputs: bool) -> Script {
+    script! {
+        { u4_nibbles_to_le_bits_toaltstack(nibble_count, check_inputs) }
         for _ in 0..4 * nibble_count {
             OP_FROMALTSTACK
         }
@@ -142,17 +182,40 @@ mod tests {
         assert!(result.success, "batch conversion failed: {result}");
     }
 
+    fn verify_little_endian_batch(inputs: &[u32], check_inputs: bool) {
+        let result = execute_script(script! {
+            for input in inputs {
+                { *input }
+            }
+            { u4_nibbles_to_le_bits(inputs.len() as u32, check_inputs) }
+            for input in inputs.iter().rev() {
+                for bit in 0..4 {
+                    { (input >> bit) & 1 }
+                    OP_EQUALVERIFY
+                }
+            }
+            OP_TRUE
+        });
+        assert!(
+            result.success,
+            "little-endian batch conversion failed: {result}"
+        );
+    }
+
     #[test]
     fn exhaustive_single_nibbles_are_correct() {
         for nibble in 0..16 {
             verify_batch(&[nibble], true);
             verify_batch(&[nibble], false);
+            verify_little_endian_batch(&[nibble], true);
+            verify_little_endian_batch(&[nibble], false);
         }
     }
 
     #[test]
     fn checked_batch_preserves_nibble_and_bit_order() {
         verify_batch(&(0..16).collect::<Vec<_>>(), true);
+        verify_little_endian_batch(&(0..16).collect::<Vec<_>>(), true);
     }
 
     #[test]
@@ -164,6 +227,16 @@ mod tests {
                 OP_TRUE
             });
             assert!(!result.success, "accepted invalid nibble {invalid}");
+
+            let result = execute_script(script! {
+                { invalid }
+                { u4_nibbles_to_le_bits(1, true) }
+                OP_TRUE
+            });
+            assert!(
+                !result.success,
+                "accepted invalid little-endian nibble {invalid}"
+            );
         }
     }
 
@@ -185,6 +258,11 @@ mod tests {
         assert!(std::panic::catch_unwind(|| u4_nibbles_to_be_bits(0, true)).is_err());
         assert!(std::panic::catch_unwind(|| {
             u4_nibbles_to_be_bits(U4_BITS_MAX_BATCH + 1, true)
+        })
+        .is_err());
+        assert!(std::panic::catch_unwind(|| u4_nibbles_to_le_bits(0, true)).is_err());
+        assert!(std::panic::catch_unwind(|| {
+            u4_nibbles_to_le_bits(U4_BITS_MAX_BATCH + 1, true)
         })
         .is_err());
     }

--- a/tests/primitive_metrics.rs
+++ b/tests/primitive_metrics.rs
@@ -1856,6 +1856,7 @@ fn metrics() -> Vec<Metric> {
     let division_witness = vec![scriptnum(14), scriptnum(119)];
     const U4_BITS_BATCH: u32 = 32;
     let u4_bits_checked_batch = u4::bits::u4_nibbles_to_be_bits(U4_BITS_BATCH, true);
+    let u4_bits_le_checked_batch = u4::bits::u4_nibbles_to_le_bits(U4_BITS_BATCH, true);
     let u4_bits_unchecked_batch = u4::bits::u4_nibbles_to_be_bits(U4_BITS_BATCH, false);
     let u4_bits_branch_batch = script! {
         for _ in 0..U4_BITS_BATCH {
@@ -2095,6 +2096,37 @@ fn metrics() -> Vec<Metric> {
             readme: "src/arithmetic/u4/README.md",
             key: "u4_bits_checked_batch32_opcodes",
             value: static_non_push_opcodes(u4_bits_checked_batch.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_bits_le_table_push",
+            value: script_len(u4::bits::u4_push_to_le_bits_table()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_bits_le_checked_batch32",
+            value: script_len(u4_bits_le_checked_batch.clone()),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_bits_le_checked_batch32_witness",
+            value: witness_size(&u4_bits_inputs),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_bits_le_checked_batch32_stack",
+            value: max_stack_items(
+                script! {
+                    { u4_bits_le_checked_batch.clone() }
+                    { u4::stack::u4_drop(4 * U4_BITS_BATCH - 1) }
+                },
+                u4_bits_inputs.clone(),
+            ),
+        },
+        Metric {
+            readme: "src/arithmetic/u4/README.md",
+            key: "u4_bits_le_checked_batch32_opcodes",
+            value: static_non_push_opcodes(u4_bits_le_checked_batch),
         },
         Metric {
             readme: "src/arithmetic/u4/README.md",


### PR DESCRIPTION
## Summary
- add a mirrored 61-item staggered lookup table that emits each u4 nibble least-significant-bit first
- preserve checked range validation, stack scheduling, and the existing 1..=234 batch bound
- record the 32-nibble boundary: 924-byte script, 64-byte representative witness, 189-item peak, and 735 static non-push opcodes

## Research result
The little-endian adapter matches the existing checked big-endian converter in script size, stack peak, and opcode count. It removes the need for a caller-side four-bit reversal when a ScriptNum or scalar consumer needs least-significant-bit-first nibble output. Witness nibbles remain hostile: checked mode enforces numeric range 0..=15, while canonical encoding and protocol binding remain caller obligations. Deployment remains unclassified; local evidence uses the repository tapscript executor with the strict stack limit.

## Tests
- `cargo test --locked arithmetic::u4::bits::tests -- --nocapture --skip batch_size_guard_matches_the_strict_stack_peak`
- `cargo test --locked arithmetic::u4::bits::tests::batch_size_guard_matches_the_strict_stack_peak -- --exact --nocapture`
- `python3 tools/kb.py validate`
- `UPDATE_PRIMITIVE_METRICS=1 cargo test --locked --test primitive_metrics` (6 passed, 1 ignored)
- `cargo test --locked --test primitive_metrics` (6 passed, 1 ignored)
- full repository test suite intentionally not run