### PR TITLE
docs(research): record compact u4 bit-table negative result

### DIFF
--- a/knowledge/negative-results/index.md
+++ b/knowledge/negative-results/index.md
@@ -10,6 +10,21 @@ final-selector variant, invalid fixed-address row-removal experiment, and
 bounded global scheduling/CNOT searches. The retained result is a 6,136-byte
 zero-key fragment with zero hints and a strict 633-item combined peak.
 
+## NR-043: Removing the u4 zero sentinel is not a practical stack win
+
+The 61-item staggered nibble-to-big-endian-bit table contains a depth-zero
+all-zero sentinel. A compact experiment removed that item, handled nibble zero
+with a branch, and shifted nonzero table indices. Exhaustive single-nibble,
+multi-nibble, and checked `-1`/`16` rejection tests passed locally, and the
+item-count formula would theoretically move the standalone table boundary
+from 234 to 235 nibbles. That is not a validated execution result: the
+checked 235-nibble script and an unchecked 32-nibble execution remained
+CPU-bound for several minutes in the pinned local interpreter and were
+terminated before completion. The added branch and repeated `OP_PICK` routing
+therefore dominate the one-item memory saving for practical use. The compact
+variant is rejected pending an execution strategy with a reproducible strict
+boundary; the existing 61-item table remains the measured construction.
+
 ## NR-001: Raw 1,024-byte SHAKE256 output exceeds the stack limit
 
 The current byte-lane SHAKE256 leaves 1,024 output items, already exceeding the


### PR DESCRIPTION
## Summary
- record an experiment removing the zero sentinel from the 61-item u4 nibble-to-bits table
- preserve the measured 61-item construction as the practical baseline
- document the theoretical 234-to-235 item-budget gain and the execution-time failure

## Evidence
- exhaustive single-nibble and multi-nibble correctness probes passed
- checked `-1` and `16` inputs were rejected
- baseline focused u4 bit tests pass
- `python3 tools/kb.py validate`
- `git diff --check`

The maximum compact schedule remained CPU-bound for several minutes in the pinned local interpreter and was terminated before completion; no strict deployment or stack-boundary claim is made. The full repository suite was not run.